### PR TITLE
Fix throw line color based on orbit prediction

### DIFF
--- a/bugfix/overlay-color/README.md
+++ b/bugfix/overlay-color/README.md
@@ -1,0 +1,14 @@
+# Overlay line color bug
+
+## Issue
+The throw line shown during body spawning was always green. It should change color based on the predicted orbit: red when a crash is inevitable, green for a stable orbit and blue when the body will escape.
+
+## Root cause
+`OverlayRenderer` hardcoded the stroke style to `'green'` and performed no analysis of the throw velocity relative to the gravitational field.
+
+## Fix
+A new helper `predictOrbitType` in `src/utils.ts` now predicts whether the thrown body will crash, remain in orbit or escape. `OverlayRenderer` uses this value to color the line red for crash course, green for stable orbit and blue for escape. Unit tests validate this behaviour.
+
+## References
+- See implementation commit.
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/src/overlayRenderer.test.ts
+++ b/spacesim/src/overlayRenderer.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { PhysicsEngine } from './physics';
+import { Vec2 } from 'planck-js';
+import { OverlayRenderer } from './renderers/overlayRenderer';
+
+class MockContext {
+  strokeStyle = '';
+  beginPath() {}
+  moveTo(_x:number,_y:number) {}
+  lineTo(_x:number,_y:number) {}
+  stroke() {}
+}
+
+describe('OverlayRenderer color', () => {
+  it('uses blue for escape velocity', () => {
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const ctx = new MockContext() as unknown as CanvasRenderingContext2D;
+    const overlay = new OverlayRenderer(ctx);
+    overlay.draw({ bodies: engine.bodies, throwLine: { start: Vec2(10,0), end: Vec2(110,0) } });
+    expect(ctx.strokeStyle).toBe('blue');
+  });
+
+  it('uses green for stable orbit', () => {
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const ctx = new MockContext() as unknown as CanvasRenderingContext2D;
+    const overlay = new OverlayRenderer(ctx);
+    overlay.draw({ bodies: engine.bodies, throwLine: { start: Vec2(10,0), end: Vec2(10,50) } });
+    expect(ctx.strokeStyle).toBe('green');
+  });
+
+  it('uses red for crash course', () => {
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const ctx = new MockContext() as unknown as CanvasRenderingContext2D;
+    const overlay = new OverlayRenderer(ctx);
+    overlay.draw({ bodies: engine.bodies, throwLine: { start: Vec2(10,0), end: Vec2(0,0) } });
+    expect(ctx.strokeStyle).toBe('red');
+  });
+});

--- a/spacesim/src/predictOrbitType.test.ts
+++ b/spacesim/src/predictOrbitType.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { Vec2 } from 'planck-js';
+import { predictOrbitType, throwVelocity } from './utils';
+import { G } from './physics';
+
+const centralPos = Vec2(0,0);
+const mass = 1;
+const radius = 1;
+
+describe('predictOrbitType', () => {
+  it('detects escape', () => {
+    const vel = throwVelocity(Vec2(10,0), Vec2(110,0));
+    expect(predictOrbitType(Vec2(10,0), vel, centralPos, mass, radius, G)).toBe('escape');
+  });
+
+  it('detects stable orbit', () => {
+    const vel = throwVelocity(Vec2(10,0), Vec2(10,50));
+    expect(predictOrbitType(Vec2(10,0), vel, centralPos, mass, radius, G)).toBe('stable');
+  });
+
+  it('detects crash', () => {
+    const vel = throwVelocity(Vec2(10,0), Vec2(0,0));
+    expect(predictOrbitType(Vec2(10,0), vel, centralPos, mass, radius, G)).toBe('crash');
+  });
+});

--- a/spacesim/src/renderers/overlayRenderer.ts
+++ b/spacesim/src/renderers/overlayRenderer.ts
@@ -1,11 +1,26 @@
 import { RenderPayload } from './types';
+import { throwVelocity, predictOrbitType } from '../utils';
+import { G } from '../physics';
 
 export class OverlayRenderer {
   constructor(private ctx: CanvasRenderingContext2D) {}
 
-  draw({ throwLine }: RenderPayload): void {
+  draw({ throwLine, bodies }: RenderPayload): void {
     if (!throwLine) return;
-    this.ctx.strokeStyle = 'green';
+    const central = bodies.reduce((a, b) =>
+      b.data.mass > a.data.mass ? b : a,
+    bodies[0]);
+    const vel = throwVelocity(throwLine.start, throwLine.end);
+    const type = predictOrbitType(
+      throwLine.start,
+      vel,
+      central.body.getPosition(),
+      central.data.mass,
+      central.data.radius,
+      G
+    );
+    this.ctx.strokeStyle =
+      type === 'escape' ? 'blue' : type === 'crash' ? 'red' : 'green';
     this.ctx.beginPath();
     this.ctx.moveTo(throwLine.start.x, throwLine.start.y);
     this.ctx.lineTo(throwLine.end.x, throwLine.end.y);

--- a/spacesim/src/utils.ts
+++ b/spacesim/src/utils.ts
@@ -16,3 +16,31 @@ export function throwVelocity(start: Vec2, end: Vec2) {
   if (speed < 5) return Vec2();
   return drag.mul(0.01 * speed / (speed + 50));
 }
+
+export type OrbitType = 'crash' | 'stable' | 'escape';
+
+export function predictOrbitType(
+  position: Vec2,
+  velocity: Vec2,
+  centralPos: Vec2,
+  centralMass: number,
+  centralRadius: number,
+  Gconst: number
+): OrbitType {
+  const rVec = Vec2.sub(position, centralPos);
+  const r = rVec.length();
+  const v2 = velocity.lengthSquared();
+  const mu = Gconst * centralMass;
+  const energy = 0.5 * v2 - mu / r;
+  if (energy < 0) {
+    const h = rVec.x * velocity.y - rVec.y * velocity.x;
+    const e = Math.sqrt(
+      Math.max(0, 1 + (2 * energy * h * h) / (mu * mu))
+    );
+    const a = -mu / (2 * energy);
+    const rp = a * (1 - e);
+    if (rp <= centralRadius) return 'crash';
+    return 'stable';
+  }
+  return 'escape';
+}


### PR DESCRIPTION
## Summary
- detect crash, stable, or escape trajectories via `predictOrbitType`
- color overlay throw line red, green or blue accordingly
- add unit tests for orbit prediction and renderer colors
- document the colour logic in bugfix notes

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68807dccc2b883209644d35abefd9e78