### PR TITLE
Document features with accurate behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 coverage/
 **/coverage/
+spacesim/test-results/

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This file is part of the initial project scaffolding and will evolve as the proj
 ## Example
 
 See [example/](example/) for a minimal TypeScript web app demonstrating the workflow in action. It provides build scripts, tests and documentation for a complete unit of work.
+
+## Features
+
+Implemented features are documented under the [feature/](feature/) directory. Each entry links to the commits and has an accompanying end-to-end test.

--- a/feature/README.md
+++ b/feature/README.md
@@ -5,3 +5,11 @@ Create a folder here for each significant feature. Document:
 - the use cases and design overview
 - architectural decisions and links to commits
 - changelog entries and related bug fixes
+
+## Implemented Features
+
+- [Drag to Spawn Bodies](drag-spawn/README.md)
+- [Pause and Reset Controls](pause-reset/README.md)
+- [Body Editor](body-editor/README.md)
+
+Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/body-editor/README.md
+++ b/feature/body-editor/README.md
@@ -1,0 +1,9 @@
+# Body Editor
+
+Clicking an existing body opens a panel to inspect and edit its data.
+
+- Allows changing name, mass, radius and color, then applying changes.
+- Delete removes the body and closes the editor.
+- The editor stays open after applying and closes when you click elsewhere.
+- Implemented in `spacesim`.
+- End-to-end coverage: `spacesim/e2e/edit.spec.ts`.

--- a/feature/drag-spawn/README.md
+++ b/feature/drag-spawn/README.md
@@ -1,0 +1,10 @@
+# Drag to Spawn Bodies
+
+Dragging on the canvas spawns a new body. The drag distance and direction determine its initial velocity using `throwVelocity`.
+
+- Very short drags still create a body but with near-zero velocity.
+- A green line shows the drag vector while held.
+- The body is created on mouse release using the parameters from the spawner panel and a unique label.
+- Clicking an existing body selects it instead of starting a drag.
+- Implemented in `spacesim`.
+- End-to-end coverage: `spacesim/e2e/spawn.spec.ts`.

--- a/feature/pause-reset/README.md
+++ b/feature/pause-reset/README.md
@@ -1,0 +1,8 @@
+# Pause and Reset Controls
+
+The toolbar at the top right provides **Pause** and **Reset** buttons.
+
+- **Pause** stops the game loop and the button text toggles to **Start**.
+- **Reset** removes all bodies, clears any drag line and current selection.
+- Implemented in `spacesim`.
+- End-to-end coverage: `spacesim/e2e/controls.spec.ts`.

--- a/practices/BUGFIX.md
+++ b/practices/BUGFIX.md
@@ -3,7 +3,9 @@
 Follow these steps whenever you address a defect:
 
 1. **Reproduce with Tests**
-   - Write a failing test that captures the bug.
+   - Write a failing test that captures the bug. This "bug test" remains in the
+     suite to guard against regressions. It can be unit, integration or end to
+     end, as long as it reproduces the issue.
    - Only begin coding the fix once the failure is verified.
 2. **Root Cause Analysis**
    - Identify why the bug occurred and document the underlying issue in a new folder under `bugfix/`.

--- a/practices/FEATURE.md
+++ b/practices/FEATURE.md
@@ -6,6 +6,8 @@ When introducing a new feature, follow these principles:
    - Write unit and integration tests first to describe the desired behaviour.
    - Do not implement functionality until failing tests prove the need.
    - Aim for at least 90% coverage as described in [Testing](TESTING.md).
+   - Provide an end-to-end test for each user-facing capability. See the
+     [Testing practices](TESTING.md) section on E2E tests.
 2. **Documentation**
    - Create a new folder under `feature/` named after the feature and include a `README.md` summarising:
      - purpose and high-level design decisions

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -2,8 +2,9 @@
 
 A simple 2D physics sandbox illustrating basic orbital mechanics. The project uses TypeScript and Planck.js to simulate gravity between bodies. The UI is built with **Preact** and composed of small components.
 
-Bodies are spawned by dragging on the canvas while the spawner panel is visible. The drag distance determines the initial velocity. Selecting an existing body opens an editor panel. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included.
-The top-right of the screen now contains **Pause** and **Reset** buttons to control the simulation.
+Bodies are spawned by dragging on the canvas while the spawner panel is visible. The drag length defines the initial velocity and short drags create a body with near-zero velocity. A green line shows the drag vector as you hold the mouse. When released a body is created with a unique label from the spawner panel.
+
+Clicking an existing body opens an editor panel. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
 
 The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks using RxJS intervals, the `PhysicsEngine` handles Planck.js dynamics and independent renderers draw bodies and overlay elements. `CompositeRenderer` runs the collection of renderers each frame. This decoupled design keeps each part focused and easy to test.
 
@@ -24,7 +25,5 @@ npm run test:e2e  # run browser tests with Playwright
 The entry page `index.html` mounts `src/main.tsx`. Core physics logic lives in `src/physics/`, the Preact components in `src/components/` and scenarios in `src/scenarios/`.
 
 The build script runs the test suite first and fails if unit test coverage drops below **90%**.
-
-The entry page `index.html` mounts `src/main.tsx`. Core physics logic lives in `src/physics/`, the Preact components in `src/components/` and scenarios in `src/scenarios/`.
 
 See [../practices](../practices) for overall development guidelines.

--- a/spacesim/e2e/controls.spec.ts
+++ b/spacesim/e2e/controls.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+const dragSpawn = async (page) => {
+  const canvas = page.locator('canvas');
+  await canvas.waitFor();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no canvas');
+  await page.mouse.move(box.x + 50, box.y + 50);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 100, box.y + 50);
+  await page.mouse.up();
+};
+
+test('pause and reset controls', async ({ page }) => {
+  await page.goto('/');
+  const pause = page.getByRole('button', { name: 'Pause' });
+  const reset = page.getByRole('button', { name: 'Reset' });
+  await pause.waitFor();
+
+  await dragSpawn(page);
+  await page.waitForTimeout(100);
+  let count = await page.evaluate(() => window.sim.bodies.length);
+  expect(count).toBe(1);
+
+  await pause.click();
+  await expect(page.getByRole('button', { name: 'Start' })).toBeVisible();
+
+  await reset.click();
+  count = await page.evaluate(() => window.sim.bodies.length);
+  expect(count).toBe(0);
+});

--- a/spacesim/e2e/edit.spec.ts
+++ b/spacesim/e2e/edit.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+const dragSpawn = async (page) => {
+  const canvas = page.locator('canvas');
+  await canvas.waitFor();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no canvas');
+  await page.mouse.move(box.x + 50, box.y + 50);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 100, box.y + 50);
+  await page.mouse.up();
+};
+
+test('edit body label', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  await dragSpawn(page);
+  await page.waitForTimeout(100);
+
+  const canvas = page.locator('canvas');
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no canvas');
+  await page.mouse.click(box.x + 50, box.y + 50);
+
+  const nameInput = page.locator('label:has-text("Name") input');
+  await nameInput.fill('Edited');
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  const label = await page.evaluate(() => window.sim.bodies[0].data.label);
+  expect(label).toBe('Edited');
+});

--- a/spacesim/e2e/spawn.spec.ts
+++ b/spacesim/e2e/spawn.spec.ts
@@ -20,3 +20,24 @@ test('dragging spawns a body', async ({ page }) => {
   console.log('count', count);
   await expect(count).toBe(1);
 });
+
+test('short drag spawns body with zero velocity', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  const canvas = page.locator('canvas');
+  await canvas.waitFor();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no canvas');
+  await page.mouse.move(box.x + 50, box.y + 50);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 52, box.y + 52);
+  await page.mouse.up();
+  await page.waitForTimeout(100);
+  const vel = await page.evaluate(() => {
+    const v = window.sim.bodies[0].body.getLinearVelocity();
+    return { x: v.x, y: v.y, count: window.sim.bodies.length };
+  });
+  expect(vel.count).toBe(1);
+  expect(Math.abs(vel.x)).toBeLessThan(0.01);
+  expect(Math.abs(vel.y)).toBeLessThan(0.01);
+});


### PR DESCRIPTION
## Summary
- clarify that short drags still spawn a body at zero speed
- document Body Editor and Pause/Reset behaviors more precisely
- update Spacesim overview for exact drag behavior
- add Playwright test for short drag velocity

## Testing
- `npm test` in `example`
- `npm test` and `npm run test:e2e` in `spacesim`


------
https://chatgpt.com/codex/tasks/task_e_68807ec593248320b8644bd0d6354c52