### PR TITLE
Add helper script for feature and bugfix records

### DIFF
--- a/practices/BUGFIX.md
+++ b/practices/BUGFIX.md
@@ -9,6 +9,7 @@ Follow these steps whenever you address a defect:
    - Identify why the bug occurred and document the underlying issue in a new folder under `bugfix/`.
    - Include notes on which parts of the architecture were affected and link to the relevant feature docs or commits.
    - Record any process issues uncovered and propose improvements.
+   - You can create the folder with [`new-record.js`](new-record.js): `node practices/new-record.js bugfix <name>`.
 3. **Implement Safely**
    - Keep the failing test in place until the fix passes.
    - Ensure unit coverage remains above the [Testing](TESTING.md) threshold.

--- a/practices/FEATURE.md
+++ b/practices/FEATURE.md
@@ -11,6 +11,7 @@ When introducing a new feature, follow these principles:
      - purpose and high-level design decisions
      - links to relevant commits and architectural documents
      - changelog entries
+   - The helper script [`new-record.js`](new-record.js) can generate this folder automatically: `node practices/new-record.js feature <name>`.
    - Update any affected architecture docs and reference this feature folder from them.
 3. **Quality Gates**
    - The build must pass with required coverage before merging.

--- a/practices/README.md
+++ b/practices/README.md
@@ -7,5 +7,6 @@ This folder collects the documentation that defines how we work.
 - [Testing](TESTING.md)
 - [Adding Features](FEATURE.md)
 - [Fixing Bugs](BUGFIX.md)
+- [Record Helper](new-record.js)
 
 Each document links to the others so you can navigate through the workflow. Review them all before contributing.

--- a/practices/new-record.js
+++ b/practices/new-record.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const [,,type,name] = process.argv;
+
+function usage(){
+  console.error('Usage: new-record.js <feature|bugfix> <name>');
+  process.exit(1);
+}
+
+if(!type || !name) usage();
+if(type !== 'feature' && type !== 'bugfix') usage();
+
+const root = path.resolve(__dirname, '..');
+const outDir = path.join(root, type, name);
+fs.mkdirSync(outDir, {recursive:true});
+
+let sections;
+if(type === 'feature'){
+  sections = [
+    '- purpose and high-level design decisions',
+    '- links to relevant commits and architectural documents',
+    '- changelog entries'
+  ];
+} else {
+  sections = [
+    '- Identify why the bug occurred and document the underlying issue in a new folder under `bugfix/`.',
+    '- Include notes on which parts of the architecture were affected and link to the relevant feature docs or commits.',
+    '- Record any process issues uncovered and propose improvements.',
+    '- In the bug\'s folder, provide a clear changelog and reference to this guide and other practice docs.',
+    '- Cross-reference previous bugfixes if the issue relates to them.'
+  ];
+}
+
+const content = `# ${name}\n\n${sections.join('\n')}\n`;
+fs.writeFileSync(path.join(outDir, 'README.md'), content);
+console.log(`Created ${path.join(type, name, 'README.md')}`);

--- a/test/new-record.test.js
+++ b/test/new-record.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+const {execSync} = require('child_process');
+const assert = require('assert');
+
+function run(cmd){
+  execSync(cmd, {stdio:'inherit'});
+}
+
+function cleanup(type, name){
+  const dir = path.join(__dirname, '..', type, name);
+  if(fs.existsSync(dir)) fs.rmSync(dir, {recursive:true, force:true});
+}
+
+try {
+  cleanup('feature', 'test-feat');
+  run('node practices/new-record.js feature test-feat');
+  const featContent = fs.readFileSync(path.join(__dirname, '..', 'feature', 'test-feat', 'README.md'), 'utf8');
+  assert(featContent.includes('purpose and high-level design decisions'));
+  cleanup('feature', 'test-feat');
+
+  cleanup('bugfix', 'test-bug');
+  run('node practices/new-record.js bugfix test-bug');
+  const bugContent = fs.readFileSync(path.join(__dirname, '..', 'bugfix', 'test-bug', 'README.md'), 'utf8');
+  assert(bugContent.includes('Identify why the bug occurred'));
+  cleanup('bugfix', 'test-bug');
+
+  console.log('tests passed');
+} catch(err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `practices/new-record.js` to generate README skeletons
- reference the helper script from practice docs
- test the script with Node

## Testing
- `node test/new-record.test.js`
- `npm test` in `example`
- `npm test` in `spacesim`


------
https://chatgpt.com/codex/tasks/task_e_688082ddc39c832082cf97220a51f90f