### PR TITLE
Add refactoring practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Welcome, coding agent! Follow these instructions whenever you work in this repos
 
 1. **Read Documentation First**
    - Review the current folder's `README.md` and `AGENTS.md` along with those of its parents.
-   - Consult the documents in [`practices/`](practices/) for testing, feature and bug fix procedures.
+   - Consult the documents in [`practices/`](practices/) for testing, feature, bug fix and refactoring procedures.
 2. **Comply with the Workflow**
    - Follow the standards defined in [`practices/CODING_RULES.md`](practices/CODING_RULES.md).
    - Format commit messages according to [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Welcome to Codex2! This repository is scaffolded using **documentation-driven de
 - `README.md` explains the purpose of the code within its folder and links to any additional documentation.
 - `AGENTS.md` provides AI-specific guidance for contributing safely and consistently.
 
-A detailed workflow for all contributors is defined in [`practices/CODING_RULES.md`](practices/CODING_RULES.md). Core practices such as testing, feature work and bug fixing are documented in the [`practices/`](practices/) folder. You should read those guidelines, including the commit message rules in [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md), before proposing any changes. Further design or architecture notes may appear in other Markdown files, and they will be referenced from the local `README.md` and `AGENTS.md`.
+A detailed workflow for all contributors is defined in [`practices/CODING_RULES.md`](practices/CODING_RULES.md). Core practices such as testing, feature work, bug fixing and refactoring are documented in the [`practices/`](practices/) folder. You should read those guidelines, including the commit message rules in [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md), before proposing any changes. Further design or architecture notes may appear in other Markdown files, and they will be referenced from the local `README.md` and `AGENTS.md`.
 
 This file is part of the initial project scaffolding and will evolve as the project grows.
 

--- a/practices/CODING_RULES.md
+++ b/practices/CODING_RULES.md
@@ -37,6 +37,7 @@ This document defines the lifecycle that all contributors must follow. It applie
 
 ## 9. Refactor with Confidence
 - Improve code clarity and structure without altering behavior.
+- Follow [REFACTORING.md](REFACTORING.md) for detailed guidance.
 - Rerun all tests after refactoring to confirm correctness.
 
 ## 10. Finalize Documentation

--- a/practices/README.md
+++ b/practices/README.md
@@ -7,6 +7,7 @@ This folder collects the documentation that defines how we work.
 - [Testing](TESTING.md)
 - [Adding Features](FEATURE.md)
 - [Fixing Bugs](BUGFIX.md)
+- [Refactoring](REFACTORING.md)
 - [Record Helper](new-record.js)
 
 Each document links to the others so you can navigate through the workflow. Review them all before contributing.

--- a/practices/REFACTORING.md
+++ b/practices/REFACTORING.md
@@ -1,0 +1,18 @@
+# Refactoring Guide
+
+Refactoring improves internal structure without changing external behaviour. Follow these guidelines before and during any refactor:
+
+1. **Verify Coverage**
+   - Ensure automated tests cover the affected code with meaningful assertions.
+   - If coverage is lacking, expand tests first so real behaviour is locked in.
+2. **Review Architecture**
+   - Compare proposed refactors against current architecture documentation.
+   - If the refactor implies architecture changes, document a proposal rather than editing architecture files directly. Await explicit approval before altering architecture docs.
+3. **Update Tests and Docs**
+   - Adjust tests to reflect any intentional behavioural changes.
+   - Update `README.md` and `AGENTS.md` files so explanations match the refactored code.
+   - Keep all practice documents and style rules in mind.
+4. **Run All Tests**
+   - Execute every available test suite after refactoring to confirm nothing broke.
+
+These steps apply to both humans and agents. Maintain the coding standards defined in this folder and seek review if uncertain. See also [CODING_RULES.md](CODING_RULES.md) for the overall workflow.


### PR DESCRIPTION
## Summary
- document refactoring procedures
- mention refactoring docs in main guidance

## Testing
- `npm test` in example
- `npm test` in spacesim
- `npm run test:e2e` in spacesim

------
https://chatgpt.com/codex/tasks/task_e_688088f18fcc8320b2d55581f172ee47