### PR TITLE
feat: show orbit overlays

### DIFF
--- a/feature/README.md
+++ b/feature/README.md
@@ -12,5 +12,6 @@ Create a folder here for each significant feature. Document:
 - [Pause and Reset Controls](pause-reset/README.md)
 - [Body Editor](body-editor/README.md)
 - [Highlight selected body](select-highlight/README.md)
+- [Orbit overlays](orbit-overlay/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/orbit-overlay/README.md
+++ b/feature/orbit-overlay/README.md
@@ -1,0 +1,7 @@
+# Orbit overlays
+
+Active bodies display a dotted line predicting their orbit.
+
+- `OverlayRenderer` simulates each body around the most massive one and draws the path.
+- Lines use the body's color but turn **blue** on escape trajectories and **red** when doomed to crash.
+- Unit tests cover the color logic in `src/overlayRenderer.test.ts`.

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -8,6 +8,8 @@ Clicking an existing body opens an editor panel. Scenarios (predefined sequences
 
 The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks using RxJS intervals, the `PhysicsEngine` handles Planck.js dynamics and independent renderers draw bodies and overlay elements. `CompositeRenderer` runs the collection of renderers each frame. This decoupled design keeps each part focused and easy to test.
 
+Bodies also render dotted orbit trails based on their current trajectory. The trail uses the body's color unless it is escaping (blue) or on a collision course (red).
+
 ## Setup
 ```bash
 npm install

--- a/spacesim/src/overlayRenderer.test.ts
+++ b/spacesim/src/overlayRenderer.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { PhysicsEngine } from './physics';
 import { Vec2 } from 'planck-js';
 import { OverlayRenderer } from './renderers/overlayRenderer';
+import { throwVelocity } from './utils';
 
 class MockContext {
   strokeStyle = '';
+  strokes: string[] = [];
   beginPath() {}
   moveTo(_x:number,_y:number) {}
   lineTo(_x:number,_y:number) {}
-  stroke() {}
+  setLineDash(_d:number[]) {}
+  stroke() { this.strokes.push(this.strokeStyle); }
 }
 
 describe('OverlayRenderer color', () => {
@@ -37,5 +40,40 @@ describe('OverlayRenderer color', () => {
     const overlay = new OverlayRenderer(ctx);
     overlay.draw({ bodies: engine.bodies, throwLine: { start: Vec2(10,0), end: Vec2(0,0) } });
     expect(ctx.strokeStyle).toBe('red');
+  });
+});
+
+describe('OverlayRenderer orbits', () => {
+  it('draws orbit in body color for stable trajectory', () => {
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const orbitVel = throwVelocity(Vec2(10,0), Vec2(10,50));
+    engine.addBody(Vec2(10,0), orbitVel, { mass: 1, radius: 1, color: 'white', label: 'b' });
+    const ctx = new MockContext() as unknown as CanvasRenderingContext2D;
+    const overlay = new OverlayRenderer(ctx);
+    overlay.draw({ bodies: engine.bodies });
+    expect(ctx.strokes[0]).toBe('white');
+  });
+
+  it('colors escape trajectory blue', () => {
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const vel = throwVelocity(Vec2(10,0), Vec2(110,0));
+    engine.addBody(Vec2(10,0), vel, { mass: 1, radius: 1, color: 'white', label: 'b' });
+    const ctx = new MockContext() as unknown as CanvasRenderingContext2D;
+    const overlay = new OverlayRenderer(ctx);
+    overlay.draw({ bodies: engine.bodies });
+    expect(ctx.strokes[0]).toBe('blue');
+  });
+
+  it('colors crash trajectory red', () => {
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const vel = throwVelocity(Vec2(10,0), Vec2(0,0));
+    engine.addBody(Vec2(10,0), vel, { mass: 1, radius: 1, color: 'white', label: 'b' });
+    const ctx = new MockContext() as unknown as CanvasRenderingContext2D;
+    const overlay = new OverlayRenderer(ctx);
+    overlay.draw({ bodies: engine.bodies });
+    expect(ctx.strokes[0]).toBe('red');
   });
 });

--- a/spacesim/src/renderers/overlayRenderer.ts
+++ b/spacesim/src/renderers/overlayRenderer.ts
@@ -1,20 +1,78 @@
 import { RenderPayload } from './types';
 import { throwVelocity, predictOrbitType } from '../utils';
 import { G } from '../physics';
+import { Vec2 } from 'planck-js';
+
+function simulateOrbit(
+  pos: Vec2,
+  vel: Vec2,
+  central: Vec2,
+  mass: number,
+  radius: number,
+  steps = 180,
+  dt = 0.1
+) {
+  const pts: Vec2[] = [];
+  let p = pos.clone();
+  let v = vel.clone();
+  for (let i = 0; i < steps; i++) {
+    const r = p.clone().sub(central);
+    const distSq = r.lengthSquared();
+    if (distSq <= radius * radius) break;
+    const acc = r.clone().mul((-G * mass) / Math.pow(distSq, 1.5));
+    v = v.clone().add(acc.mul(dt));
+    p = p.clone().add(v.clone().mul(dt));
+    pts.push(p.clone());
+  }
+  return pts;
+}
 
 export class OverlayRenderer {
   constructor(private ctx: CanvasRenderingContext2D) {}
 
   draw({ throwLine, bodies }: RenderPayload): void {
-    if (!throwLine) return;
+    if (!bodies.length) return;
     const central = bodies.reduce((a, b) =>
       b.data.mass > a.data.mass ? b : a,
     bodies[0]);
+    const cPos = central.body.getPosition();
+    this.ctx.setLineDash([2, 2]);
+    for (const b of bodies) {
+      if (b === central) continue;
+      const pos = b.body.getPosition();
+      const vel = b.body.getLinearVelocity();
+      const type = predictOrbitType(
+        pos,
+        vel,
+        cPos,
+        central.data.mass,
+        central.data.radius,
+        G
+      );
+      this.ctx.strokeStyle =
+        type === 'escape' ? 'blue' : type === 'crash' ? 'red' : b.data.color;
+      const pts = simulateOrbit(
+        pos,
+        vel,
+        cPos,
+        central.data.mass,
+        central.data.radius
+      );
+      if (pts.length) {
+        this.ctx.beginPath();
+        this.ctx.moveTo(pos.x, pos.y);
+        for (const p of pts) this.ctx.lineTo(p.x, p.y);
+        this.ctx.stroke();
+      }
+    }
+    this.ctx.setLineDash([]);
+
+    if (!throwLine) return;
     const vel = throwVelocity(throwLine.start, throwLine.end);
     const type = predictOrbitType(
       throwLine.start,
       vel,
-      central.body.getPosition(),
+      cPos,
       central.data.mass,
       central.data.radius,
       G


### PR DESCRIPTION
## Summary
- render orbit trails in OverlayRenderer
- show overlay stroke styles for orbits in new tests
- document orbit overlay feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68808ee31e7883208444d52bcb95cb64