### PR TITLE
Fix documentation about folder-level files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,6 @@ Welcome, coding agent! Follow these instructions whenever you work in this repos
    - Format commit messages according to [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md).
    - Write tests before implementing any change and ensure they all pass.
 3. **Maintain Local Instructions**
-   - Every subfolder contains its own `AGENTS.md` with additional guidance. Read them before editing files in that folder.
+   - Some subfolders include their own `AGENTS.md` with additional guidance. If present, read it before editing files in that folder.
 
 These practices must not be altered without explicit approval. Raise concerns rather than modifying them silently.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Project Overview
 
-Welcome to Codex2! This repository is scaffolded using **documentation-driven development**. Every directory in this project must include a `README.md` and an `AGENTS.md` file. These documents ensure that both human developers and AI coding agents understand the structure, intent, and rules of the codebase.
+Welcome to Codex2! This repository is scaffolded using **documentation-driven development**. Create a `README.md` and an `AGENTS.md` in a folder only when it adds context or rules that aren't already covered by its parent directories. These documents help both human developers and AI coding agents understand the structure, intent, and rules of the codebase.
 
-- `README.md` explains the purpose of the code within its folder and links to any additional documentation.
-- `AGENTS.md` provides AI-specific guidance for contributing safely and consistently.
+- `README.md` explains the purpose of the code within its folder and links to any additional documentation. Add one only when the folder introduces concepts not documented elsewhere.
+- `AGENTS.md` provides AI-specific guidance for contributing safely and consistently. Include it when specialised instructions are needed for that folder.
 - For any UI work consult [`practices/UI.md`](practices/UI.md) for design guidelines.
 
 A detailed workflow for all contributors is defined in [`practices/CODING_RULES.md`](practices/CODING_RULES.md). Core practices such as testing, feature work, bug fixing and refactoring are documented in the [`practices/`](practices/) folder. You should read those guidelines, including the commit message rules in [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md), before proposing any changes. Further design or architecture notes may appear in other Markdown files, and they will be referenced from the local `README.md` and `AGENTS.md`.

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,5 @@
+# Git Hooks
+
+This folder contains helper scripts for Git. The `commit-msg` hook checks commit messages with **commitlint**.
+
+See [../practices/COMMIT_MESSAGE.md](../practices/COMMIT_MESSAGE.md) for installation instructions.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codex2",
   "version": "1.0.0",
-  "description": "Welcome to Codex2! This repository is scaffolded using **documentation-driven development**. Every directory in this project must include a `README.md` and an `AGENTS.md` file. These documents ensure that both human developers and AI coding agents understand the structure, intent, and rules of the codebase.",
+  "description": "Welcome to Codex2! This repository is scaffolded using **documentation-driven development**. Directories include `README.md` and `AGENTS.md` only when they add context beyond what parent folders describe. These documents help both human developers and AI coding agents understand the structure, intent, and rules of the codebase.",
   "main": "index.js",
   "directories": {
     "example": "example"


### PR DESCRIPTION
## Summary
- clarify that README.md and AGENTS.md are optional
- adjust AGENTS instructions to match
- update package description
- add README for githooks

## Testing
- `npm test` *(fails: no tests specified)*
- `npm install` & `npm test` in `example`
- `npm install` & `npm test` in `spacesim`


------
https://chatgpt.com/codex/tasks/task_e_688090d7b7088320b48bf1323a9e4585