### PR TITLE
Add live body position and velocity editing

### DIFF
--- a/feature/body-editor/README.md
+++ b/feature/body-editor/README.md
@@ -2,8 +2,10 @@
 
 Clicking an existing body opens a panel to inspect and edit its data.
 
-- Allows changing name, mass, radius and color, then applying changes.
+- Mass, radius, color, **position** and **velocity** can all be changed and applied back to the running simulation.
+- Position and velocity fields refresh each frame to show live values.
 - Delete removes the body and closes the editor.
 - The editor stays open after applying and closes when you click elsewhere.
+- `Simulation` emits a `bodyUpdate` event whenever changes are applied.
 - Implemented in `spacesim`.
 - End-to-end coverage: `spacesim/e2e/edit.spec.ts`.

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -4,7 +4,7 @@ A simple 2D physics sandbox illustrating basic orbital mechanics. The project us
 
 Bodies are spawned by dragging on the canvas while the spawner panel is visible. The drag length defines the initial velocity and short drags create a body with near-zero velocity. A green line shows the drag vector as you hold the mouse. When released a body is created with a unique label from the spawner panel.
 
-Clicking an existing body opens an editor panel. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
+Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
 
 The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks using RxJS intervals, the `PhysicsEngine` handles Planck.js dynamics and independent renderers draw bodies and overlay elements. `CompositeRenderer` runs the collection of renderers each frame. This decoupled design keeps each part focused and easy to test.
 

--- a/spacesim/e2e/edit.spec.ts
+++ b/spacesim/e2e/edit.spec.ts
@@ -29,3 +29,27 @@ test('edit body label', async ({ page }) => {
   const label = await page.evaluate(() => window.sim.bodies[0].data.label);
   expect(label).toBe('Edited');
 });
+
+test('edit body velocity', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  await dragSpawn(page);
+  const pause = page.getByRole('button', { name: 'Pause' });
+  await pause.click();
+  await page.waitForTimeout(50);
+
+  const canvas = page.locator('canvas');
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no canvas');
+  await page.mouse.click(box.x + 50, box.y + 50);
+
+  const vxInput = page.locator('label:has-text("Vel X") input');
+  await vxInput.fill('5');
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  const vel = await page.evaluate(() => {
+    const v = window.sim.bodies[0].body.getLinearVelocity();
+    return { x: v.x, y: v.y };
+  });
+  expect(Math.round(vel.x)).toBe(5);
+});

--- a/spacesim/src/components/BodyEditor.tsx
+++ b/spacesim/src/components/BodyEditor.tsx
@@ -1,21 +1,54 @@
 import { useState, useEffect } from 'preact/hooks';
 import { Simulation } from '../simulation';
+import { Vec2 } from 'planck-js';
 import type { BodyData } from '../physics';
 
 interface Props {
   sim: Simulation;
   body: ReturnType<Simulation['addBody']> | null;
   onDeselect: () => void;
+  frame: number;
 }
 
-export default function BodyEditor({ sim, body, onDeselect }: Props) {
-  const [state, setState] = useState<BodyData | null>(body?.data || null);
+interface BodyState extends BodyData {
+  posX: number;
+  posY: number;
+  velX: number;
+  velY: number;
+}
+
+export default function BodyEditor({ sim, body, onDeselect, frame }: Props) {
+  const [state, setState] = useState<BodyState | null>(() => {
+    if (!body) return null;
+    const pos = body.body.getPosition();
+    const vel = body.body.getLinearVelocity();
+    return { ...body.data, posX: pos.x, posY: pos.y, velX: vel.x, velY: vel.y };
+  });
+  const [edited, setEdited] = useState(false);
   useEffect(() => {
-    setState(body?.data || null);
-  }, [body]);
-  if (!body) return null;
+    if (!body) return setState(null);
+    if (edited) return;
+    const pos = body.body.getPosition();
+    const vel = body.body.getLinearVelocity();
+    setState({
+      ...body.data,
+      posX: pos.x,
+      posY: pos.y,
+      velX: vel.x,
+      velY: vel.y,
+    });
+  }, [body, frame, edited]);
+  if (!body || !state) return null;
   const apply = () => {
-    sim.updateBody(body, state!);
+    setEdited(false);
+    sim.updateBody(body, {
+      mass: state.mass,
+      radius: state.radius,
+      color: state.color,
+      label: state.label,
+      position: Vec2(state.posX, state.posY),
+      velocity: Vec2(state.velX, state.velY),
+    });
   };
   const remove = () => {
     sim.removeBody(body);
@@ -23,10 +56,14 @@ export default function BodyEditor({ sim, body, onDeselect }: Props) {
   };
   return (
     <div style={{ position: 'absolute', top: '140px', left: '10px', background: '#2228', padding: '0.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-      <label>Name <input value={state!.label} onInput={(e) => setState({ ...state!, label: (e.target as HTMLInputElement).value })} /></label>
-      <label>Mass <input type="number" step="0.1" value={state!.mass} onInput={(e) => setState({ ...state!, mass: parseFloat((e.target as HTMLInputElement).value) })} /></label>
-      <label>Radius <input type="number" step="1" value={state!.radius} onInput={(e) => setState({ ...state!, radius: parseFloat((e.target as HTMLInputElement).value) })} /></label>
-      <label>Color <input type="color" value={state!.color} onInput={(e) => setState({ ...state!, color: (e.target as HTMLInputElement).value })} /></label>
+      <label>Name <input value={state.label} onInput={e => { setEdited(true); setState({ ...state, label: (e.target as HTMLInputElement).value }); }} /></label>
+      <label>Mass <input type="number" step="0.1" value={state.mass} onInput={e => { setEdited(true); setState({ ...state, mass: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
+      <label>Radius <input type="number" step="1" value={state.radius} onInput={e => { setEdited(true); setState({ ...state, radius: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
+      <label>Color <input type="color" value={state.color} onInput={e => { setEdited(true); setState({ ...state, color: (e.target as HTMLInputElement).value }); }} /></label>
+      <label>Pos X <input type="number" step="0.1" value={state.posX} onInput={e => { setEdited(true); setState({ ...state, posX: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
+      <label>Pos Y <input type="number" step="0.1" value={state.posY} onInput={e => { setEdited(true); setState({ ...state, posY: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
+      <label>Vel X <input type="number" step="0.1" value={state.velX} onInput={e => { setEdited(true); setState({ ...state, velX: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
+      <label>Vel Y <input type="number" step="0.1" value={state.velY} onInput={e => { setEdited(true); setState({ ...state, velY: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
       <button onClick={apply}>Apply</button>
       <button onClick={remove}>Delete</button>
     </div>

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -21,7 +21,7 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
   const [selected, setSelected] = useState<ReturnType<Simulation['addBody']> | null>(null);
   const [spawnParams, setSpawnParams] = useState({ mass:1, radius:5, color:'#ffffff', label:'body' });
   const [dragStart, setDragStart] = useState<Vec2 | null>(null);
-  const [, setFrame] = useState(0);
+  const [frame, setFrame] = useState(0);
 
   useEffect(() => {
     const off = sim.onRender(() => setFrame(f => f + 1));
@@ -73,7 +73,7 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
         <button onClick={reset}>Reset</button>
       </div>
       <BodySpawner sim={sim} disabled={!!selected || !!dragStart} params={spawnParams} onChange={setSpawnParams} />
-      <BodyEditor sim={sim} body={selected} onDeselect={()=>setSelected(null)} />
+      <BodyEditor sim={sim} body={selected} onDeselect={()=>setSelected(null)} frame={frame} />
       <BodyList sim={sim} selected={selected} onSelect={b=>setSelected(b)} />
     </div>
   );

--- a/spacesim/src/components/bodyEditor.test.tsx
+++ b/spacesim/src/components/bodyEditor.test.tsx
@@ -1,10 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from 'preact';
 import BodyEditor from './BodyEditor';
 
 const makeBody = (label: string) => ({
   data: { label, mass: 1, radius: 1, color: '#fff' },
-  body: {} as any
+  body: { getPosition: () => ({ x: 0, y: 0 }), getLinearVelocity: () => ({ x: 0, y: 0 }) } as any
 });
 
 const sim = {
@@ -16,13 +16,30 @@ describe('BodyEditor', () => {
   it('updates fields when body prop changes', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
-    render(<BodyEditor sim={sim} body={makeBody('a')} onDeselect={() => {}} />, container);
+    render(<BodyEditor sim={sim} body={makeBody('a')} onDeselect={() => {}} frame={0} />, container);
     const input = container.querySelector('input') as HTMLInputElement;
     expect(input.value).toBe('a');
     render(null, container);
-    render(<BodyEditor sim={sim} body={makeBody('b')} onDeselect={() => {}} />, container);
+    render(<BodyEditor sim={sim} body={makeBody('b')} onDeselect={() => {}} frame={1} />, container);
     await new Promise(r => setTimeout(r));
     const input2 = container.querySelector('input') as HTMLInputElement;
     expect(input2.value).toBe('b');
   });
+
+  it('shows updated position each frame', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const body = makeBody('a');
+    render(<BodyEditor sim={sim} body={body} onDeselect={() => {}} frame={0} />, container);
+    const labels = Array.from(container.querySelectorAll('label'));
+    const posX = labels.find(l => l.textContent?.startsWith('Pos X'))!.querySelector('input') as HTMLInputElement;
+    expect(posX.value).toBe('0');
+    (body.body as any).getPosition = () => ({ x: 2, y: 0 });
+    render(<BodyEditor sim={sim} body={body} onDeselect={() => {}} frame={1} />, container);
+    await new Promise(r => setTimeout(r));
+    const labels2 = Array.from(container.querySelectorAll('label'));
+    const posX2 = labels2.find(l => l.textContent?.startsWith('Pos X'))!.querySelector('input') as HTMLInputElement;
+    expect(posX2.value).toBe('2');
+  });
+
 });

--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -84,4 +84,22 @@ describe('Sandbox gravity', () => {
     expect(body.data.label).toBe('b');
     expect(body.data.color).toBe('blue');
   });
+
+  it('updates body position', () => {
+    const sb = new PhysicsEngine();
+    const body = sb.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: 'a' });
+    sb.updateBody(body, { position: Vec2(5, 6) });
+    const pos = body.body.getPosition();
+    expect(pos.x).toBeCloseTo(5);
+    expect(pos.y).toBeCloseTo(6);
+  });
+
+  it('updates body velocity', () => {
+    const sb = new PhysicsEngine();
+    const body = sb.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: 'a' });
+    sb.updateBody(body, { velocity: Vec2(3, 4) });
+    const vel = body.body.getLinearVelocity();
+    expect(vel.x).toBeCloseTo(3);
+    expect(vel.y).toBeCloseTo(4);
+  });
 });

--- a/spacesim/src/physics/engine.ts
+++ b/spacesim/src/physics/engine.ts
@@ -7,6 +7,11 @@ export interface BodyData {
   label: string;
 }
 
+export interface BodyUpdate extends Partial<BodyData> {
+  position?: Vec2;
+  velocity?: Vec2;
+}
+
 export const G = 1; // gravitational constant (arbitrary units)
 
 export class PhysicsEngine {
@@ -47,7 +52,10 @@ export class PhysicsEngine {
     );
   }
 
-  updateBody(target: { body: planck.Body; data: BodyData }, updates: Partial<BodyData>) {
+  updateBody(
+    target: { body: planck.Body; data: BodyData },
+    updates: Partial<BodyData> & { position?: Vec2; velocity?: Vec2 }
+  ) {
     if (updates.mass !== undefined) {
       const fixture = target.body.getFixtureList();
       if (fixture) {
@@ -67,6 +75,12 @@ export class PhysicsEngine {
     }
     if (updates.label !== undefined) target.data.label = updates.label;
     if (updates.color !== undefined) target.data.color = updates.color;
+    if (updates.position) {
+      target.body.setPosition(updates.position);
+    }
+    if (updates.velocity) {
+      target.body.setLinearVelocity(updates.velocity);
+    }
   }
 
   private applyGravity() {

--- a/spacesim/src/physics/index.ts
+++ b/spacesim/src/physics/index.ts
@@ -1,1 +1,1 @@
-export { PhysicsEngine, type BodyData, G } from './engine';
+export { PhysicsEngine, type BodyData, type BodyUpdate, G } from './engine';

--- a/spacesim/src/simulation.ts
+++ b/spacesim/src/simulation.ts
@@ -1,7 +1,7 @@
 import { Vec2 } from 'planck-js';
 import { createEventBus, EventBus } from './core/eventBus';
 import { GameLoop } from './core/gameLoop';
-import { PhysicsEngine, BodyData } from './physics';
+import { PhysicsEngine, BodyData, BodyUpdate } from './physics';
 import { CompositeRenderer } from './renderers/compositeRenderer';
 import { BodyRenderer } from './renderers/bodyRenderer';
 import { OverlayRenderer } from './renderers/overlayRenderer';
@@ -18,6 +18,7 @@ export interface ScenarioEvent {
 interface Events {
   tick: number;
   render: RenderPayload;
+  bodyUpdate: { body: ReturnType<PhysicsEngine['addBody']>; updates: BodyUpdate };
 }
 
 export class Simulation {
@@ -88,8 +89,9 @@ export class Simulation {
     return this.engine.findBody(pos);
   }
 
-  updateBody(b: ReturnType<PhysicsEngine['addBody']>, d: Partial<BodyData>) {
+  updateBody(b: ReturnType<PhysicsEngine['addBody']>, d: BodyUpdate) {
     this.engine.updateBody(b, d);
+    this.bus.emit('bodyUpdate', { body: b, updates: d });
   }
 
   removeBody(b: ReturnType<PhysicsEngine['addBody']>) {


### PR DESCRIPTION
## Summary
- allow updating body position and velocity via `PhysicsEngine.updateBody`
- emit `bodyUpdate` events from `Simulation`
- display and edit position and velocity in BodyEditor
- document new capability and record the feature
- test physics updates and BodyEditor frame refresh
- add end-to-end test for motion editing
- consolidate docs under Body Editor feature

## Testing
- `npm test`
- `npm run test:e2e` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68808e00ebd4832099fa7d423e141465