### PR TITLE
Add view navigation controls

### DIFF
--- a/feature/zoom-pan/README.md
+++ b/feature/zoom-pan/README.md
@@ -1,0 +1,9 @@
+# Zoom, Pan and Center View
+
+The simulation view can be zoomed, panned and centered on a body.
+
+- `Simulation` tracks a `view` with `center` and `zoom` values and exposes helper methods.
+- `CompositeRenderer` applies the transform to all renderers.
+- `CanvasView` converts mouse coordinates using `screenToWorld`.
+- Toolbar controls allow zooming with +/-, panning with arrows and centering on the selected body.
+- Documented in this feature and covered by unit tests in `src/view.test.ts`.

--- a/spacesim/src/components/CanvasView.tsx
+++ b/spacesim/src/components/CanvasView.tsx
@@ -18,7 +18,8 @@ export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onM
   }, [sim]);
   const toVec = (e: MouseEvent) => {
     const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
-    return Vec2(e.clientX - rect.left, e.clientY - rect.top);
+    const p = Vec2(e.clientX - rect.left, e.clientY - rect.top);
+    return sim.screenToWorld(p);
   };
   const handleClick = (e: MouseEvent) => {
     if (onClick) onClick(toVec(e));

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -63,14 +63,35 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
   };
 
   const toggleRun = () => setRunning(r=>!r);
-  const reset = () => { sim.reset(); setSelected(null); setDragStart(null); };
+  const reset = () => { sim.reset(); setSelected(null); setDragStart(null); sim.resetView(); };
+  const zoomIn = () => { sim.zoom(1.2); };
+  const zoomOut = () => { sim.zoom(1/1.2); };
+  const pan = (dx:number, dy:number) => { sim.pan(dx / sim.view.zoom, dy / sim.view.zoom); };
+  const center = () => { if (selected) sim.centerOn(selected); else sim.resetView(); };
 
   return (
     <div style={{ position:'relative', width:'100%', height:'100%' }}>
       <CanvasView sim={sim} onMouseDown={down} onMouseMove={move} onMouseUp={up} />
-      <div style={{ position:'absolute', top:'10px', right:'10px', display:'flex', gap:'0.5rem' }}>
-        <button onClick={toggleRun}>{running ? 'Pause' : 'Start'}</button>
-        <button onClick={reset}>Reset</button>
+      <div style={{ position:'absolute', top:'10px', right:'10px', display:'flex', flexDirection:'column', gap:'0.25rem' }}>
+        <div style={{ display:'flex', gap:'0.25rem' }}>
+          <button onClick={toggleRun}>{running ? 'Pause' : 'Start'}</button>
+          <button onClick={reset}>Reset</button>
+          <button onClick={center}>Center</button>
+        </div>
+        <div style={{ display:'flex', gap:'0.25rem', justifyContent:'center' }}>
+          <button onClick={zoomIn}>+</button>
+          <button onClick={zoomOut}>-</button>
+        </div>
+        <div style={{ display:'flex', justifyContent:'center' }}>
+          <button onClick={()=>pan(0,-20)}>↑</button>
+        </div>
+        <div style={{ display:'flex', gap:'0.25rem', justifyContent:'center' }}>
+          <button onClick={()=>pan(-20,0)}>←</button>
+          <button onClick={()=>pan(20,0)}>→</button>
+        </div>
+        <div style={{ display:'flex', justifyContent:'center' }}>
+          <button onClick={()=>pan(0,20)}>↓</button>
+        </div>
       </div>
       <BodySpawner sim={sim} disabled={!!selected || !!dragStart} params={spawnParams} onChange={setSpawnParams} />
       <BodyEditor sim={sim} body={selected} onDeselect={()=>setSelected(null)} frame={frame} />

--- a/spacesim/src/components/canvasView.test.tsx
+++ b/spacesim/src/components/canvasView.test.tsx
@@ -6,7 +6,7 @@ import { Vec2 } from 'planck-js';
 describe('CanvasView', () => {
   it('reports click coordinates relative to canvas', () => {
     const click = vi.fn();
-    const sim = { setCanvas: vi.fn() } as any;
+    const sim = { setCanvas: vi.fn(), screenToWorld: (v: Vec2) => v } as any;
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(<CanvasView sim={sim} onClick={click} />, container);

--- a/spacesim/src/renderers/compositeRenderer.ts
+++ b/spacesim/src/renderers/compositeRenderer.ts
@@ -16,6 +16,12 @@ export class CompositeRenderer {
 
   draw(payload: RenderPayload): void {
     this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
+    this.ctx.save();
+    const view = payload.view ?? { center: { x: 0, y: 0 }, zoom: 1 };
+    this.ctx.translate(this.ctx.canvas.width / 2, this.ctx.canvas.height / 2);
+    this.ctx.scale(view.zoom, view.zoom);
+    this.ctx.translate(-view.center.x, -view.center.y);
     for (const r of this.renderers) r.draw(payload);
+    this.ctx.restore();
   }
 }

--- a/spacesim/src/renderers/types.ts
+++ b/spacesim/src/renderers/types.ts
@@ -10,4 +10,5 @@ export interface RenderableBody {
 export interface RenderPayload {
   bodies: RenderableBody[];
   throwLine?: { start: Vec2; end: Vec2 };
+  view?: { center: Vec2; zoom: number };
 }

--- a/spacesim/src/view.test.ts
+++ b/spacesim/src/view.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { Simulation } from './simulation';
+import { Vec2 } from 'planck-js';
+
+function setupSim() {
+  const sim = new Simulation();
+  const canvas = { width: 200, height: 200 } as HTMLCanvasElement;
+  (sim as any).canvas = canvas;
+  return sim;
+}
+
+describe('view transforms', () => {
+  it('converts between world and screen coordinates', () => {
+    const sim = setupSim();
+    sim.setZoom(2);
+    sim.pan(10, 10);
+    const world = Vec2(10, 10);
+    const screen = sim.worldToScreen(world);
+    expect(screen.x).toBeCloseTo(100);
+    expect(screen.y).toBeCloseTo(100);
+    const round = sim.screenToWorld(screen);
+    expect(round.x).toBeCloseTo(world.x);
+    expect(round.y).toBeCloseTo(world.y);
+  });
+
+  it('centers on body and resets zoom', () => {
+    const sim = setupSim();
+    const body = sim.addBody(Vec2(5, 5), Vec2(), { mass:1, radius:1, color:'#fff', label:'b' });
+    sim.setZoom(3);
+    sim.pan(20, 20);
+    sim.centerOn(body);
+    expect(sim.view.zoom).toBe(1);
+    expect(sim.view.center.x).toBeCloseTo(5);
+    expect(sim.view.center.y).toBeCloseTo(5);
+  });
+});


### PR DESCRIPTION
## Summary
- support zooming and panning the simulation view
- add `center` control to focus on the selected body
- expose view helpers and transform rendering
- convert canvas interactions to world coordinates
- document the zoom-pan feature

## Testing
- `npm test --prefix spacesim`
- `npm run test:e2e --prefix spacesim` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68809591580c8320bf725e2881a8f902