### PR TITLE
Add simulation speed control

### DIFF
--- a/feature/README.md
+++ b/feature/README.md
@@ -13,5 +13,6 @@ Create a folder here for each significant feature. Document:
 - [Body Editor](body-editor/README.md)
 - [Highlight selected body](select-highlight/README.md)
 - [Orbit overlays](orbit-overlay/README.md)
+- [Simulation Speed Control](speed-control/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/speed-control/README.md
+++ b/feature/speed-control/README.md
@@ -1,0 +1,9 @@
+# Simulation Speed Control
+
+The simulation toolbar now lets users change how fast physics runs.
+
+- `Simulation` tracks a speed multiplier (1–64) and scales the timestep.
+- New buttons «««, xN and »»» adjust or reset the speed.
+- Rendering stays fixed at 25 fps.
+- Covered by unit tests in `src/simulation.test.ts` and e2e in `e2e/controls.spec.ts`.
+

--- a/spacesim/e2e/controls.spec.ts
+++ b/spacesim/e2e/controls.spec.ts
@@ -29,3 +29,22 @@ test('pause and reset controls', async ({ page }) => {
   count = await page.evaluate(() => window.sim.bodies.length);
   expect(count).toBe(0);
 });
+
+test('speed controls update label', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  const faster = page.getByRole('button', { name: '>>>' });
+  const slower = page.getByRole('button', { name: '<<<' });
+  const display = page.getByRole('button', { name: /^x/ });
+  await display.waitFor();
+  await expect(display).toHaveText('x1');
+  await faster.click();
+  await expect(display).toHaveText('x2');
+  await slower.click();
+  await expect(display).toHaveText('x1');
+  await faster.click();
+  await faster.click();
+  await expect(display).toHaveText('x4');
+  await display.click();
+  await expect(display).toHaveText('x1');
+});

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -22,6 +22,7 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
   const [spawnParams, setSpawnParams] = useState({ mass:1, radius:5, color:'#ffffff', label:'body' });
   const [dragStart, setDragStart] = useState<Vec2 | null>(null);
   const [frame, setFrame] = useState(0);
+  const [speed, setSpeed] = useState(sim.speed);
 
   useEffect(() => {
     const off = sim.onRender(() => setFrame(f => f + 1));
@@ -68,6 +69,9 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
   const zoomOut = () => { sim.zoom(1/1.2); };
   const pan = (dx:number, dy:number) => { sim.pan(dx / sim.view.zoom, dy / sim.view.zoom); };
   const center = () => { if (selected) sim.centerOn(selected); else sim.resetView(); };
+  const faster = () => { sim.speedUp(); setSpeed(sim.speed); };
+  const slower = () => { sim.slowDown(); setSpeed(sim.speed); };
+  const resetSpeed = () => { sim.resetSpeed(); setSpeed(sim.speed); };
 
   return (
     <div style={{ position:'relative', width:'100%', height:'100%' }}>
@@ -77,6 +81,11 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
           <button onClick={toggleRun}>{running ? 'Pause' : 'Start'}</button>
           <button onClick={reset}>Reset</button>
           <button onClick={center}>Center</button>
+        </div>
+        <div style={{ display:'flex', gap:'0.25rem', justifyContent:'center' }}>
+          <button onClick={slower}>{'<<<'}</button>
+          <button onClick={resetSpeed}>{`x${speed}`}</button>
+          <button onClick={faster}>{'>>>'}</button>
         </div>
         <div style={{ display:'flex', gap:'0.25rem', justifyContent:'center' }}>
           <button onClick={zoomIn}>+</button>

--- a/spacesim/src/simulation.test.ts
+++ b/spacesim/src/simulation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Simulation } from './simulation';
 import { solarSystem } from './scenarios/solarSystem';
 
@@ -9,5 +9,14 @@ describe('Simulation scenarios', () => {
     // run steps enough to process scenario events
     for (let i = 0; i < 10; i++) sim['step'](0.1); // using private method access for test
     expect(sim.bodies.length).toBeGreaterThan(1);
+  });
+
+  it('scales timestep with speed multiplier', () => {
+    const sim = new Simulation();
+    const stepSpy = vi.spyOn(sim['engine'], 'step');
+    sim.speedUp();
+    sim['step'](0.5 as any);
+    const arg = stepSpy.mock.calls[0][0];
+    expect(arg).toBeCloseTo(1);
   });
 });


### PR DESCRIPTION
## Summary
- implement speed multiplier in Simulation and UI controls
- test new multiplier logic
- document simulation speed control feature

## Testing
- `npm test`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_6880987146cc8320a6bbc4e6f00e94b9