### PR TITLE
Fix docs path handling

### DIFF
--- a/spacesim/src/components/DocsView.tsx
+++ b/spacesim/src/components/DocsView.tsx
@@ -10,7 +10,7 @@ export default function DocsView() {
   const [content, setContent] = useState<string>('');
 
   useEffect(() => {
-    fetch('/docs/version.json')
+    fetch('docs/version.json')
       .then(r => r.json())
       .then(v => {
         const max = Number(v.major);
@@ -22,7 +22,7 @@ export default function DocsView() {
 
   const changeMajor = (m: string) => {
     setMajor(m);
-    fetch(`/docs/${m}/manifest.json`)
+    fetch(`docs/${m}/manifest.json`)
       .then(r => r.json())
       .then((man: Manifest) => {
         setFiles(man.files);
@@ -32,7 +32,7 @@ export default function DocsView() {
   };
 
   const loadFile = (maj: string, file: string) => {
-    fetch(`/docs/${maj}/${file}`)
+    fetch(`docs/${maj}/${file}`)
       .then(r => r.text())
       .then(t => setContent(marked.parse(t)))
       .catch(() => setContent('Documentation not found'));

--- a/spacesim/src/components/docsView.test.tsx
+++ b/spacesim/src/components/docsView.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe('DocsView', () => {
-  it('loads README on mount', async () => {
+  it('loads README on mount using relative paths', async () => {
     const responses = [
       { json: () => Promise.resolve({ major: 1 }) },
       { json: () => Promise.resolve({ files: ['README.md'] }) },
@@ -23,6 +23,9 @@ describe('DocsView', () => {
     render(<DocsView />, container);
     await new Promise(r => setTimeout(r, 20));
     expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls[0][0]).toBe('docs/version.json');
+    expect(fetchMock.mock.calls[1][0]).toBe('docs/1/manifest.json');
+    expect(fetchMock.mock.calls[2][0]).toBe('docs/1/README.md');
     expect(container.innerHTML).toContain('<h1>Hello</h1>');
   });
 });


### PR DESCRIPTION
## Summary
- adjust DocsView to fetch docs relative to the app rather than from root
- verify DocsView uses relative paths

## Testing
- `npm test` in `spacesim`
- `node test/generate-docs.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6880b5e19bb08320baee9dba7bb7a14e