### PR TITLE
Add Three.js overlay rendering

### DIFF
--- a/feature/README.md
+++ b/feature/README.md
@@ -14,5 +14,6 @@ Create a folder here for each significant feature. Document:
 - [Highlight selected body](select-highlight/README.md)
 - [Orbit overlays](orbit-overlay/README.md)
 - [Simulation Speed Control](speed-control/README.md)
+- [3D Renderer](three-renderer/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/orbit-overlay/README.md
+++ b/feature/orbit-overlay/README.md
@@ -2,6 +2,6 @@
 
 Active bodies display a dotted line predicting their orbit.
 
-- `OverlayRenderer` simulates each body around the most massive one and draws the path.
+- `ThreeRenderer` now simulates each body around the most massive one and draws the path using dashed Three.js lines.
 - Lines use the body's color but turn **blue** on escape trajectories and **red** when doomed to crash.
-- Unit tests cover the color logic in `src/overlayRenderer.test.ts`.
+- Unit tests cover the color logic in `src/threeRenderer.test.ts`.

--- a/feature/three-renderer/README.md
+++ b/feature/three-renderer/README.md
@@ -1,0 +1,5 @@
+# 3D Renderer
+
+The simulation now draws bodies using [Three.js](https://threejs.org/). A new `ThreeRenderer` replaces the previous canvas based renderer. Spheres are synced with the physics engine each frame and rendered via an orthographic camera. Overlay elements like predicted orbits and the drag vector are also drawn with Three.js lines.
+
+Related commits document the implementation and accompanying unit test.

--- a/spacesim/package-lock.json
+++ b/spacesim/package-lock.json
@@ -13,7 +13,8 @@
         "mitt": "^3.0.1",
         "planck-js": "^0.3.0",
         "preact": "^10.26.9",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "three": "^0.164.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.54.1",
@@ -3269,6 +3270,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/three": {
+      "version": "0.164.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.164.1.tgz",
+      "integrity": "sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/spacesim/package.json
+++ b/spacesim/package.json
@@ -19,15 +19,16 @@
     "playwright": "^1.54.1",
     "typescript": "^5.8.3",
     "vite": "^7.0.5",
-    "vitest": "^3.2.4",
-    "vite-plugin-static-copy": "^3.1.1"
+    "vite-plugin-static-copy": "^3.1.1",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@preact/preset-vite": "^2.10.2",
+    "marked": "^9.1.2",
     "mitt": "^3.0.1",
     "planck-js": "^0.3.0",
     "preact": "^10.26.9",
     "rxjs": "^7.8.1",
-    "marked": "^9.1.2"
+    "three": "^0.164.0"
   }
 }

--- a/spacesim/src/renderers/threeRenderer.ts
+++ b/spacesim/src/renderers/threeRenderer.ts
@@ -1,0 +1,167 @@
+import {
+  Scene,
+  WebGLRenderer,
+  OrthographicCamera,
+  SphereGeometry,
+  MeshBasicMaterial,
+  Mesh,
+  Line,
+  LineBasicMaterial,
+  LineDashedMaterial,
+  BufferGeometry,
+  Vector3,
+  Color,
+} from 'three';
+import type planck from 'planck-js';
+import type { EventBus } from '../core/eventBus';
+import { RenderPayload } from './types';
+import { predictOrbitType, throwVelocity } from '../utils';
+import { simulateOrbit } from './overlayRenderer';
+import { G } from '../physics';
+
+export class ThreeRenderer {
+  private scene = new Scene();
+  private camera: OrthographicCamera;
+  private renderer: WebGLRenderer;
+  private bodyMeshes = new Map<planck.Body, Mesh>();
+  private orbitLines = new Map<planck.Body, Line>();
+  private dragLine?: Line;
+
+  constructor(private canvas: HTMLCanvasElement, bus: EventBus<{ render: RenderPayload }>) {
+    this.renderer = new WebGLRenderer({ canvas });
+    this.renderer.setSize(canvas.width, canvas.height);
+    this.camera = new OrthographicCamera(
+      canvas.width / -2,
+      canvas.width / 2,
+      canvas.height / 2,
+      canvas.height / -2,
+      0.1,
+      1000
+    );
+    this.camera.position.z = 100;
+    bus.on('render', (p) => this.draw(p));
+  }
+
+  private syncBodies(bodies: RenderPayload['bodies']) {
+    for (const { body, data } of bodies) {
+      let mesh = this.bodyMeshes.get(body);
+      if (!mesh) {
+        mesh = new Mesh(
+          new SphereGeometry(data.radius, 8, 8),
+          new MeshBasicMaterial({ color: data.color })
+        );
+        this.scene.add(mesh);
+        this.bodyMeshes.set(body, mesh);
+      }
+      const pos = body.getPosition();
+      mesh.position.set(pos.x, pos.y, 0);
+    }
+    for (const [b, mesh] of Array.from(this.bodyMeshes.entries())) {
+      if (!bodies.find((obj) => obj.body === b)) {
+        this.scene.remove(mesh);
+        this.bodyMeshes.delete(b);
+      }
+    }
+  }
+
+  private updateOrbits(bodies: RenderPayload['bodies']) {
+    if (!bodies.length) return;
+    const central = bodies.reduce((a, b) =>
+      b.data.mass > a.data.mass ? b : a,
+    bodies[0]);
+    const cPos = central.body.getPosition();
+
+    const active = new Set(bodies.map((b) => b.body));
+    for (const [b, line] of Array.from(this.orbitLines.entries())) {
+      if (!active.has(b) || b === central.body) {
+        this.scene.remove(line);
+        this.orbitLines.delete(b);
+      }
+    }
+
+    for (const b of bodies) {
+      if (b === central) continue;
+      const pos = b.body.getPosition();
+      const vel = b.body.getLinearVelocity();
+      const type = predictOrbitType(
+        pos,
+        vel,
+        cPos,
+        central.data.mass,
+        central.data.radius,
+        G,
+      );
+      const pts = simulateOrbit(
+        pos,
+        vel,
+        cPos,
+        central.data.mass,
+        central.data.radius,
+        type,
+      );
+      const color =
+        type === 'escape' ? 'blue' : type === 'crash' ? 'red' : b.data.color;
+      const geom = new BufferGeometry().setFromPoints(
+        pts.map((p) => new Vector3(p.x, p.y, 0)),
+      );
+      const material = new LineDashedMaterial({ color, dashSize: 2, gapSize: 2 });
+      let line = this.orbitLines.get(b.body);
+      if (!line) {
+        line = new Line(geom, material);
+        line.computeLineDistances();
+        this.scene.add(line);
+        this.orbitLines.set(b.body, line);
+      } else {
+        this.scene.remove(line);
+        line.geometry.dispose();
+        (line.material as any).dispose?.();
+        line.geometry = geom;
+        line.material = material;
+        line.computeLineDistances();
+        this.scene.add(line);
+      }
+    }
+  }
+
+  private updateDragLine(bodies: RenderPayload['bodies'], line?: { start: planck.Vec2; end: planck.Vec2 }) {
+    if (!bodies.length) return;
+    const central = bodies.reduce((a, b) =>
+      b.data.mass > a.data.mass ? b : a,
+    bodies[0]);
+    const cPos = central.body.getPosition();
+    if (!line) {
+      if (this.dragLine) {
+        this.scene.remove(this.dragLine);
+        this.dragLine = undefined;
+      }
+      return;
+    }
+    const vel = throwVelocity(line.start, line.end);
+    const type = predictOrbitType(line.start, vel, cPos, central.data.mass, central.data.radius, G);
+    const color = type === 'escape' ? 'blue' : type === 'crash' ? 'red' : 'green';
+    const geom = new BufferGeometry().setFromPoints([
+      new Vector3(line.start.x, line.start.y, 0),
+      new Vector3(line.end.x, line.end.y, 0),
+    ]);
+    if (!this.dragLine) {
+      this.dragLine = new Line(geom, new LineBasicMaterial({ color }));
+      this.scene.add(this.dragLine);
+    } else {
+      this.dragLine.geometry.dispose();
+      (this.dragLine.material as LineBasicMaterial).color = new Color(color);
+      this.dragLine.geometry = geom;
+    }
+  }
+
+  draw({ bodies, view, throwLine }: RenderPayload) {
+    this.syncBodies(bodies);
+    this.updateOrbits(bodies);
+    this.updateDragLine(bodies, throwLine);
+    const v = view ?? { center: { x: 0, y: 0 }, zoom: 1 };
+    this.camera.position.x = v.center.x;
+    this.camera.position.y = v.center.y;
+    this.camera.zoom = v.zoom;
+    this.camera.updateProjectionMatrix();
+    this.renderer.render(this.scene, this.camera);
+  }
+}

--- a/spacesim/src/simulation.ts
+++ b/spacesim/src/simulation.ts
@@ -2,9 +2,7 @@ import { Vec2 } from 'planck-js';
 import { createEventBus, EventBus } from './core/eventBus';
 import { GameLoop } from './core/gameLoop';
 import { PhysicsEngine, BodyData, BodyUpdate } from './physics';
-import { CompositeRenderer } from './renderers/compositeRenderer';
-import { BodyRenderer } from './renderers/bodyRenderer';
-import { OverlayRenderer } from './renderers/overlayRenderer';
+import { ThreeRenderer } from './renderers/threeRenderer';
 import { RenderPayload } from './renderers/types';
 
 export interface ScenarioEvent {
@@ -25,7 +23,7 @@ export class Simulation {
   private engine = new PhysicsEngine();
   private bus: EventBus<Events> = createEventBus<Events>();
   private loop = new GameLoop(this.bus, 1 / 25);
-  private renderer?: CompositeRenderer;
+  private renderer?: ThreeRenderer;
   private time = 0;
   private scenario?: ScenarioEvent[];
   private canvas?: HTMLCanvasElement;
@@ -56,11 +54,7 @@ export class Simulation {
 
   setCanvas(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
-    const ctx = canvas.getContext('2d')!;
-    this.renderer = new CompositeRenderer(ctx, this.bus, [
-      new BodyRenderer(ctx),
-      new OverlayRenderer(ctx),
-    ]);
+    this.renderer = new ThreeRenderer(canvas, this.bus);
   }
 
   get view() { return this._view; }

--- a/spacesim/src/threeRenderer.test.ts
+++ b/spacesim/src/threeRenderer.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ThreeRenderer } from './renderers/threeRenderer';
+import { createEventBus } from './core/eventBus';
+import { PhysicsEngine } from './physics';
+import { Vec2 } from 'planck-js';
+import { throwVelocity } from './utils';
+
+vi.mock('three', () => {
+  class Scene { objects:any[]=[]; add(o:any){this.objects.push(o);} remove(o:any){this.objects=this.objects.filter(x=>x!==o);} }
+  class WebGLRenderer { setSize(){} render(){} }
+  class OrthographicCamera { position={x:0,y:0,z:0}; zoom=1; constructor(){} updateProjectionMatrix(){} }
+  class SphereGeometry { constructor(public r:number,_s?:number,_s2?:number){} dispose(){} }
+  class MeshBasicMaterial { color:string; constructor(public opts:any){this.color=opts.color;} dispose(){} }
+  class LineBasicMaterial { color:string; constructor(public opts:any){this.color=opts.color;} dispose(){} }
+  class LineDashedMaterial { color:string; dashSize:number; gapSize:number; constructor(public opts:any){ this.color=opts.color; this.dashSize=opts.dashSize; this.gapSize=opts.gapSize; } dispose(){} }
+  class BufferGeometry { points:any[]=[]; setFromPoints(p:any[]){ this.points=p; return this; } dispose(){} }
+  class Mesh { position={x:0,y:0,z:0,set(x:number,y:number,z:number){this.x=x;this.y=y;this.z=z;}}; constructor(public g:any,public m:any){} }
+  class Line { geometry:any; material:any; constructor(g:any,m:any){ this.geometry=g; this.material=m; } computeLineDistances(){} }
+  class Vector3 { constructor(public x:number,public y:number,public z:number){} }
+  return { Scene, WebGLRenderer, OrthographicCamera, SphereGeometry, MeshBasicMaterial, Mesh, LineBasicMaterial, LineDashedMaterial, BufferGeometry, Line, Vector3 };
+});
+
+describe('ThreeRenderer', () => {
+  it('positions meshes at body coordinates', () => {
+    const canvas = { width: 200, height: 200 } as HTMLCanvasElement;
+    const bus = createEventBus<any>();
+    const renderer = new ThreeRenderer(canvas, bus);
+    const engine = new PhysicsEngine();
+    const body = engine.addBody(Vec2(5, 6), Vec2(), { mass:1, radius:1, color:'#fff', label:'b' });
+    bus.emit('render', { bodies: engine.bodies });
+    const mesh = (renderer as any).bodyMeshes.get(body.body);
+    expect(mesh.position.x).toBeCloseTo(5);
+    expect(mesh.position.y).toBeCloseTo(6);
+  });
+
+  it('draws orbit line in body color when stable', () => {
+    const canvas = { width: 200, height: 200 } as HTMLCanvasElement;
+    const bus = createEventBus<any>();
+    const renderer = new ThreeRenderer(canvas, bus);
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    const vel = throwVelocity(Vec2(10,0), Vec2(10,50));
+    const satellite = engine.addBody(Vec2(10, 0), vel, { mass: 1, radius: 1, color: 'white', label: 's' });
+    bus.emit('render', { bodies: engine.bodies });
+    const line = (renderer as any).orbitLines.get(satellite.body);
+    expect(line.material.color).toBe('white');
+  });
+
+  it('colors drag line blue on escape trajectory', () => {
+    const canvas = { width: 200, height: 200 } as HTMLCanvasElement;
+    const bus = createEventBus<any>();
+    const renderer = new ThreeRenderer(canvas, bus);
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0,0), Vec2(), { mass: 1, radius: 1, color: 'yellow', label: 'c' });
+    bus.emit('render', { bodies: engine.bodies, throwLine: { start: Vec2(10,0), end: Vec2(110,0) } });
+    const drag = (renderer as any).dragLine;
+    expect(drag.material.color).toBe('blue');
+  });
+});


### PR DESCRIPTION
## Summary
- render predicted orbits and drag vector with Three.js
- test overlay colours for orbits and drag line
- document overlay support in 3D renderer

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880b88a1fdc8320b5a7198ef7c09c64