### PR TITLE
Fix 3D renderer coordinate and label issues

### DIFF
--- a/bugfix/three-renderer-fixes/README.md
+++ b/bugfix/three-renderer-fixes/README.md
@@ -1,0 +1,17 @@
+# 3D renderer issues
+
+The switch to `ThreeRenderer` introduced a few visual glitches:
+
+- Pointer coordinates did not account for `devicePixelRatio`, causing spawned bodies to appear offset on high-DPI screens.
+- Orbit lines persisted after `Simulation.reset()` because `ThreeRenderer` kept them in a map when no bodies were present.
+- Body labels were no longer drawn since the canvas renderer handled text and was removed.
+
+## Fix
+
+- `CanvasView` now scales the canvas and pointer coordinates by `devicePixelRatio`.
+- `ThreeRenderer.updateOrbits` clears all lines when no bodies are provided.
+- A new `BodyLabels` component renders body names using absolutely positioned HTML elements.
+
+See related tests and commits.
+
+References: [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/src/components/BodyLabels.tsx
+++ b/spacesim/src/components/BodyLabels.tsx
@@ -1,0 +1,29 @@
+import { Simulation } from '../simulation';
+
+interface Props { sim: Simulation; frame: number }
+
+export default function BodyLabels({ sim }: Props) {
+  return (
+    <>
+      {sim.bodies.map((b) => {
+        const pos = sim.worldToScreen(b.body.getPosition());
+        return (
+          <div
+            key={b.data.label}
+            style={{
+              position: 'absolute',
+              left: `${pos.x + b.data.radius + 2}px`,
+              top: `${pos.y - 10}px`,
+              pointerEvents: 'none',
+              color: '#fff',
+              fontSize: '12px',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {b.data.label}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/spacesim/src/components/CanvasView.tsx
+++ b/spacesim/src/components/CanvasView.tsx
@@ -12,13 +12,18 @@ export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onM
   useEffect(() => {
     if (!ref.current) return;
     const canvas = ref.current;
-    canvas.width = canvas.clientWidth;
-    canvas.height = canvas.clientHeight;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = canvas.clientWidth * dpr;
+    canvas.height = canvas.clientHeight * dpr;
     sim.setCanvas(canvas);
   }, [sim]);
   const toVec = (e: MouseEvent) => {
     const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
-    const p = Vec2(e.clientX - rect.left, e.clientY - rect.top);
+    const dpr = window.devicePixelRatio || 1;
+    const p = Vec2(
+      (e.clientX - rect.left) * dpr,
+      (e.clientY - rect.top) * dpr
+    );
     return sim.screenToWorld(p);
   };
   const handleClick = (e: MouseEvent) => {

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -3,6 +3,7 @@ import CanvasView from './CanvasView';
 import BodyList from './BodyList';
 import BodyEditor from './BodyEditor';
 import BodySpawner from './BodySpawner';
+import BodyLabels from './BodyLabels';
 import { Simulation, type ScenarioEvent } from '../simulation';
 import { Vec2 } from 'planck-js';
 import { uniqueName, throwVelocity } from '../utils';
@@ -105,6 +106,7 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
       <BodySpawner sim={sim} disabled={!!selected || !!dragStart} params={spawnParams} onChange={setSpawnParams} />
       <BodyEditor sim={sim} body={selected} onDeselect={()=>setSelected(null)} frame={frame} />
       <BodyList sim={sim} selected={selected} onSelect={b=>setSelected(b)} />
+      <BodyLabels sim={sim} frame={frame} />
     </div>
   );
 }

--- a/spacesim/src/components/bodyLabels.test.tsx
+++ b/spacesim/src/components/bodyLabels.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'preact';
+import BodyLabels from './BodyLabels';
+import { Vec2 } from 'planck-js';
+
+const body = {
+  body: { getPosition: () => Vec2(5, 6) },
+  data: { label: 'b', mass:1, radius:2, color: '#fff' }
+};
+
+const sim = {
+  bodies: [body],
+  worldToScreen: (v: any) => v
+} as any;
+
+describe('BodyLabels', () => {
+  it('renders label at screen position', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<BodyLabels sim={sim} frame={0} />, container);
+    const div = container.querySelector('div') as HTMLElement;
+    expect(div.textContent).toBe('b');
+    expect(div.style.left).toBe(`${5 + 2 + 2}px`);
+    expect(div.style.top).toBe(`${6 - 10}px`);
+  });
+});

--- a/spacesim/src/components/canvasView.test.tsx
+++ b/spacesim/src/components/canvasView.test.tsx
@@ -17,4 +17,24 @@ describe('CanvasView', () => {
     expect(pos.x).toBeCloseTo(5);
     expect(pos.y).toBeCloseTo(5);
   });
+
+  it('scales coordinates with devicePixelRatio', () => {
+    const click = vi.fn();
+    const screenToWorld = vi.fn((v: Vec2) => v);
+    const sim = { setCanvas: vi.fn(), screenToWorld } as any;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const orig = window.devicePixelRatio;
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+    render(<CanvasView sim={sim} onClick={click} />, container);
+    const canvas = container.querySelector('canvas')!;
+    Object.defineProperty(canvas, 'clientWidth', { value: 100 });
+    Object.defineProperty(canvas, 'clientHeight', { value: 100 });
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width:100, height:100 } as any);
+    canvas.dispatchEvent(new MouseEvent('click', { clientX:10, clientY:15 }));
+    const arg = screenToWorld.mock.calls[0][0] as ReturnType<typeof Vec2>;
+    expect(arg.x).toBeCloseTo(20);
+    expect(arg.y).toBeCloseTo(30);
+    Object.defineProperty(window, 'devicePixelRatio', { value: orig });
+  });
 });

--- a/spacesim/src/renderers/threeRenderer.ts
+++ b/spacesim/src/renderers/threeRenderer.ts
@@ -65,7 +65,13 @@ export class ThreeRenderer {
   }
 
   private updateOrbits(bodies: RenderPayload['bodies']) {
-    if (!bodies.length) return;
+    if (!bodies.length) {
+      for (const line of this.orbitLines.values()) {
+        this.scene.remove(line);
+      }
+      this.orbitLines.clear();
+      return;
+    }
     const central = bodies.reduce((a, b) =>
       b.data.mass > a.data.mass ? b : a,
     bodies[0]);

--- a/spacesim/src/threeRenderer.test.ts
+++ b/spacesim/src/threeRenderer.test.ts
@@ -56,4 +56,18 @@ describe('ThreeRenderer', () => {
     const drag = (renderer as any).dragLine;
     expect(drag.material.color).toBe('blue');
   });
+
+  it('clears orbit lines when no bodies', () => {
+    const canvas = { width: 200, height: 200 } as HTMLCanvasElement;
+    const bus = createEventBus<any>();
+    const renderer = new ThreeRenderer(canvas, bus);
+    const engine = new PhysicsEngine();
+    engine.addBody(Vec2(0, 0), Vec2(), { mass:1, radius:1, color:'yellow', label:'c' });
+    const vel = throwVelocity(Vec2(10,0), Vec2(10,50));
+    engine.addBody(Vec2(10,0), vel, { mass:1, radius:1, color:'white', label:'s' });
+    bus.emit('render', { bodies: engine.bodies });
+    expect((renderer as any).orbitLines.size).toBe(1);
+    bus.emit('render', { bodies: [] });
+    expect((renderer as any).orbitLines.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- account for `devicePixelRatio` when mapping mouse coords
- clear orbit lines after reset
- render body labels using HTML overlay
- document root causes in bugfix record
- add regression tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880bcf5e08c8320a62e0be1be69b7ff