### PR TITLE
Regenerate docs after 3D renderer feature

### DIFF
--- a/docs/1/feature/README.md
+++ b/docs/1/feature/README.md
@@ -14,5 +14,6 @@ Create a folder here for each significant feature. Document:
 - [Highlight selected body](select-highlight/README.md)
 - [Orbit overlays](orbit-overlay/README.md)
 - [Simulation Speed Control](speed-control/README.md)
+- [3D Renderer](three-renderer/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/docs/1/feature/orbit-overlay/README.md
+++ b/docs/1/feature/orbit-overlay/README.md
@@ -2,6 +2,6 @@
 
 Active bodies display a dotted line predicting their orbit.
 
-- `OverlayRenderer` simulates each body around the most massive one and draws the path.
+- `ThreeRenderer` now simulates each body around the most massive one and draws the path using dashed Three.js lines.
 - Lines use the body's color but turn **blue** on escape trajectories and **red** when doomed to crash.
-- Unit tests cover the color logic in `src/overlayRenderer.test.ts`.
+- Unit tests cover the color logic in `src/threeRenderer.test.ts`.

--- a/docs/1/feature/three-renderer/README.md
+++ b/docs/1/feature/three-renderer/README.md
@@ -1,0 +1,5 @@
+# 3D Renderer
+
+The simulation now draws bodies using [Three.js](https://threejs.org/). A new `ThreeRenderer` replaces the previous canvas based renderer. Spheres are synced with the physics engine each frame and rendered via an orthographic camera. Overlay elements like predicted orbits and the drag vector are also drawn with Three.js lines.
+
+Related commits document the implementation and accompanying unit test.

--- a/docs/1/generated.json
+++ b/docs/1/generated.json
@@ -2,5 +2,5 @@
   "version": "1.0.0",
   "minor": 0,
   "patch": 0,
-  "timestamp": 1753265118390
+  "timestamp": 1753267784202
 }

--- a/docs/1/manifest.json
+++ b/docs/1/manifest.json
@@ -15,6 +15,7 @@
     "feature/performance-tests/README.md",
     "feature/select-highlight/README.md",
     "feature/speed-control/README.md",
+    "feature/three-renderer/README.md",
     "feature/zoom-pan/README.md",
     "githooks/README.md",
     "practices/BUGFIX.md",


### PR DESCRIPTION
## Summary
- regenerate documentation for v1
- include new ThreeRenderer feature in docs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_e_6880be17e4c08320bf01c6bd831633b6