### PR TITLE
Fix docs tab path

### DIFF
--- a/spacesim/src/components/DocsView.tsx
+++ b/spacesim/src/components/DocsView.tsx
@@ -9,8 +9,10 @@ export default function DocsView() {
   const [majors, setMajors] = useState<number[]>([]);
   const [content, setContent] = useState<string>('');
 
+  const base = import.meta.env.BASE_URL;
+
   useEffect(() => {
-    fetch('docs/version.json')
+    fetch(`${base}docs/version.json`)
       .then(r => r.json())
       .then(v => {
         const max = Number(v.major);
@@ -22,7 +24,7 @@ export default function DocsView() {
 
   const changeMajor = (m: string) => {
     setMajor(m);
-    fetch(`docs/${m}/manifest.json`)
+    fetch(`${base}docs/${m}/manifest.json`)
       .then(r => r.json())
       .then((man: Manifest) => {
         setFiles(man.files);
@@ -32,7 +34,7 @@ export default function DocsView() {
   };
 
   const loadFile = (maj: string, file: string) => {
-    fetch(`docs/${maj}/${file}`)
+    fetch(`${base}docs/${maj}/${file}`)
       .then(r => r.text())
       .then(t => setContent(marked.parse(t)))
       .catch(() => setContent('Documentation not found'));

--- a/spacesim/src/components/docsView.test.tsx
+++ b/spacesim/src/components/docsView.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe('DocsView', () => {
-  it('loads README on mount using relative paths', async () => {
+  it('loads README on mount using base-relative paths', async () => {
     const responses = [
       { json: () => Promise.resolve({ major: 1 }) },
       { json: () => Promise.resolve({ files: ['README.md'] }) },
@@ -22,10 +22,11 @@ describe('DocsView', () => {
     document.body.appendChild(container);
     render(<DocsView />, container);
     await new Promise(r => setTimeout(r, 20));
+    const base = import.meta.env.BASE_URL;
     expect(fetchMock).toHaveBeenCalled();
-    expect(fetchMock.mock.calls[0][0]).toBe('docs/version.json');
-    expect(fetchMock.mock.calls[1][0]).toBe('docs/1/manifest.json');
-    expect(fetchMock.mock.calls[2][0]).toBe('docs/1/README.md');
+    expect(fetchMock.mock.calls[0][0]).toBe(`${base}docs/version.json`);
+    expect(fetchMock.mock.calls[1][0]).toBe(`${base}docs/1/manifest.json`);
+    expect(fetchMock.mock.calls[2][0]).toBe(`${base}docs/1/README.md`);
     expect(container.innerHTML).toContain('<h1>Hello</h1>');
   });
 });


### PR DESCRIPTION
## Summary
- handle base path in DocsView so hosted docs load correctly
- update docsView test to match new paths

## Testing
- `npm test` (fails: Error: no test specified)
- `cd spacesim && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880bfe8cc58832087c5427756193cbc