### PR TITLE
Fix label position scaling

### DIFF
--- a/bugfix/label-position-offset/README.md
+++ b/bugfix/label-position-offset/README.md
@@ -1,0 +1,20 @@
+# Label position offset
+
+## Issue
+Body labels did not align with their rendered bodies on high-DPI screens. After
+fixing the spawn coordinate mapping the labels still appeared shifted to the
+right and down.
+
+## Root cause
+`BodyLabels` used `Simulation.worldToScreen` which returns canvas pixel
+coordinates. These values are scaled by `devicePixelRatio` while the absolutely
+positioned HTML elements expect CSS pixel units. The mismatch produced an
+offset equal to the ratio between canvas and style pixels.
+
+## Fix
+Labels now divide the `worldToScreen` result by `devicePixelRatio` before
+setting their `left` and `top` styles. A unit test covers the scaling logic.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/docs/1/bugfix/label-position-offset/README.md
+++ b/docs/1/bugfix/label-position-offset/README.md
@@ -1,0 +1,20 @@
+# Label position offset
+
+## Issue
+Body labels did not align with their rendered bodies on high-DPI screens. After
+fixing the spawn coordinate mapping the labels still appeared shifted to the
+right and down.
+
+## Root cause
+`BodyLabels` used `Simulation.worldToScreen` which returns canvas pixel
+coordinates. These values are scaled by `devicePixelRatio` while the absolutely
+positioned HTML elements expect CSS pixel units. The mismatch produced an
+offset equal to the ratio between canvas and style pixels.
+
+## Fix
+Labels now divide the `worldToScreen` result by `devicePixelRatio` before
+setting their `left` and `top` styles. A unit test covers the scaling logic.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/docs/1/generated.json
+++ b/docs/1/generated.json
@@ -2,5 +2,5 @@
   "version": "1.0.0",
   "minor": 0,
   "patch": 0,
-  "timestamp": 1753268805534
+  "timestamp": 1753269460331
 }

--- a/docs/1/manifest.json
+++ b/docs/1/manifest.json
@@ -5,6 +5,7 @@
     "bugfix/README.md",
     "bugfix/body-editor-refresh/README.md",
     "bugfix/click-coord-offset/README.md",
+    "bugfix/label-position-offset/README.md",
     "bugfix/overlay-color/README.md",
     "bugfix/three-renderer-fixes/README.md",
     "example/AGENTS.md",

--- a/spacesim/src/components/BodyLabels.tsx
+++ b/spacesim/src/components/BodyLabels.tsx
@@ -7,13 +7,16 @@ export default function BodyLabels({ sim }: Props) {
     <>
       {sim.bodies.map((b) => {
         const pos = sim.worldToScreen(b.body.getPosition());
+        const dpr = window.devicePixelRatio || 1;
+        const screenX = pos.x / dpr;
+        const screenY = pos.y / dpr;
         return (
           <div
             key={b.data.label}
             style={{
               position: 'absolute',
-              left: `${pos.x + b.data.radius + 2}px`,
-              top: `${pos.y - 10}px`,
+              left: `${screenX + b.data.radius + 2}px`,
+              top: `${screenY - 10}px`,
               pointerEvents: 'none',
               color: '#fff',
               fontSize: '12px',

--- a/spacesim/src/components/bodyLabels.test.tsx
+++ b/spacesim/src/components/bodyLabels.test.tsx
@@ -23,4 +23,17 @@ describe('BodyLabels', () => {
     expect(div.style.left).toBe(`${5 + 2 + 2}px`);
     expect(div.style.top).toBe(`${6 - 10}px`);
   });
+
+  it('scales position with devicePixelRatio', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const orig = (window as any).devicePixelRatio;
+    Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+    const sim2 = { bodies: [body], worldToScreen: () => Vec2(10, 12) } as any;
+    render(<BodyLabels sim={sim2} frame={0} />, container);
+    const div = container.querySelector('div') as HTMLElement;
+    expect(div.style.left).toBe(`${10 / 2 + 2 + 2}px`);
+    expect(div.style.top).toBe(`${12 / 2 - 10}px`);
+    Object.defineProperty(window, 'devicePixelRatio', { value: orig });
+  });
 });


### PR DESCRIPTION
## Summary
- adjust BodyLabels to scale screen coordinates using devicePixelRatio
- verify scaling in a new unit test
- document label position offset bug

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880c3abd6108320bc1c286d460db9d3