### PR TITLE
Fix docs viewer by regenerating manifest

### DIFF
--- a/bugfix/docs-manifest-conflict/README.md
+++ b/bugfix/docs-manifest-conflict/README.md
@@ -1,0 +1,10 @@
+# Docs manifest conflict
+
+## Issue
+The documentation view in Spacesim failed to load any files. The version dropdown listed `1`, but selecting it produced an empty list.
+
+## Root cause
+`spacesim/docs/1/manifest.json` contained unresolved merge conflict markers. The invalid JSON caused the `fetch` call in `DocsView` to fail when parsing, so the list of documentation files never loaded.
+
+## Fix
+The docs were regenerated using `scripts/generate-docs.js`, which overwrites the manifest and other files with valid JSON. The `docs` view now loads correctly.

--- a/spacesim/docs/1/bugfix/docs-manifest-conflict/README.md
+++ b/spacesim/docs/1/bugfix/docs-manifest-conflict/README.md
@@ -1,0 +1,10 @@
+# Docs manifest conflict
+
+## Issue
+The documentation view in Spacesim failed to load any files. The version dropdown listed `1`, but selecting it produced an empty list.
+
+## Root cause
+`spacesim/docs/1/manifest.json` contained unresolved merge conflict markers. The invalid JSON caused the `fetch` call in `DocsView` to fail when parsing, so the list of documentation files never loaded.
+
+## Fix
+The docs were regenerated using `scripts/generate-docs.js`, which overwrites the manifest and other files with valid JSON. The `docs` view now loads correctly.

--- a/spacesim/docs/1/bugfix/label-position-offset/README.md
+++ b/spacesim/docs/1/bugfix/label-position-offset/README.md
@@ -1,0 +1,20 @@
+# Label position offset
+
+## Issue
+Body labels did not align with their rendered bodies on high-DPI screens. After
+fixing the spawn coordinate mapping the labels still appeared shifted to the
+right and down.
+
+## Root cause
+`BodyLabels` used `Simulation.worldToScreen` which returns canvas pixel
+coordinates. These values are scaled by `devicePixelRatio` while the absolutely
+positioned HTML elements expect CSS pixel units. The mismatch produced an
+offset equal to the ratio between canvas and style pixels.
+
+## Fix
+Labels now divide the `worldToScreen` result by `devicePixelRatio` before
+setting their `left` and `top` styles. A unit test covers the scaling logic.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/docs/1/generated.json
+++ b/spacesim/docs/1/generated.json
@@ -2,9 +2,5 @@
   "version": "1.0.0",
   "minor": 0,
   "patch": 0,
-<<<<<<< HEAD:spacesim/docs/1/generated.json
-  "timestamp": 1753269643532
-=======
-  "timestamp": 1753269460331
->>>>>>> main:docs/1/generated.json
+  "timestamp": 1753270330147
 }

--- a/spacesim/docs/1/manifest.json
+++ b/spacesim/docs/1/manifest.json
@@ -5,10 +5,8 @@
     "bugfix/README.md",
     "bugfix/body-editor-refresh/README.md",
     "bugfix/click-coord-offset/README.md",
-<<<<<<< HEAD:spacesim/docs/1/manifest.json
-=======
+    "bugfix/docs-manifest-conflict/README.md",
     "bugfix/label-position-offset/README.md",
->>>>>>> main:docs/1/manifest.json
     "bugfix/overlay-color/README.md",
     "bugfix/three-renderer-fixes/README.md",
     "example/AGENTS.md",

--- a/spacesim/src/components/docsView.test.tsx
+++ b/spacesim/src/components/docsView.test.tsx
@@ -29,4 +29,18 @@ describe('DocsView', () => {
     expect(fetchMock.mock.calls[2][0]).toBe(`${base}docs/1/README.md`);
     expect(container.innerHTML).toContain('<h1>Hello</h1>');
   });
+  it('handles invalid manifest gracefully', async () => {
+    const responses = [
+      { json: () => Promise.resolve({ major: 1 }) },
+      { json: () => Promise.reject(new SyntaxError('invalid')) }
+    ];
+    const fetchMock = vi.fn(() => Promise.resolve(responses.shift()!));
+    global.fetch = fetchMock as any;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<DocsView />, container);
+    await new Promise(r => setTimeout(r, 20));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(container.querySelectorAll('li').length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- regenerate docs after resolving merge conflicts
- add missing label-position-offset docs
- document docs manifest bug
- test handling of invalid manifest data

## Testing
- `npm --prefix spacesim install`
- `npm --prefix spacesim test`
- `npm --prefix example install`
- `npm --prefix example test`
- `node test/generate-docs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6880c72ad95883209d12c42b16c7ed00