### PR TITLE
Add view controls e2e tests

### DIFF
--- a/spacesim/e2e/view.spec.ts
+++ b/spacesim/e2e/view.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+const dragSpawn = async (page) => {
+  const canvas = page.locator('canvas');
+  await canvas.waitFor();
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error('no canvas');
+  await page.mouse.move(box.x + 50, box.y + 50);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 100, box.y + 50);
+  await page.mouse.up();
+};
+
+test('zoom and pan controls change view', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  await page.getByRole('button', { name: '+' }).click();
+  await page.getByRole('button', { name: '→' }).click();
+  const view = await page.evaluate(() => ({ zoom: window.sim.view.zoom, x: window.sim.view.center.x }));
+  expect(view.zoom).toBeCloseTo(1.2);
+  expect(view.x).toBeCloseTo(16.67, 1);
+  await page.getByRole('button', { name: '-' }).click();
+  const zoom = await page.evaluate(() => window.sim.view.zoom);
+  expect(zoom).toBeCloseTo(1);
+});
+
+test('center button focuses selected body', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  await dragSpawn(page);
+  await page.waitForTimeout(100);
+  const item = page.locator('li').first();
+  await item.click();
+  await page.getByRole('button', { name: '+' }).click();
+  await page.getByRole('button', { name: 'Center' }).click();
+  const pos = await page.evaluate(() => {
+    const b = window.sim.bodies[0].body.getPosition();
+    return { x: b.x, y: b.y };
+  });
+  const center = await page.evaluate(() => ({ x: window.sim.view.center.x, y: window.sim.view.center.y, zoom: window.sim.view.zoom }));
+  expect(center.zoom).toBe(1);
+  expect(center.x).toBeCloseTo(pos.x);
+  expect(center.y).toBeCloseTo(pos.y);
+});

--- a/spacesim/playwright.config.ts
+++ b/spacesim/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:4173'
   },
+  workers: 1,
   webServer: {
     command: 'npx vite --port 4173',
     port: 4173,


### PR DESCRIPTION
## Summary
- add e2e coverage for zoom, pan and centering behaviour
- run Playwright tests sequentially to avoid race conditions

## Testing
- `npm test` in example
- `npm test` in spacesim
- `npm run test:e2e` in spacesim
- `node test/new-record.test.js`
- `node test/generate-docs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6880cbf02ea88320a1ae5600370934f4