### PR TITLE
Reduce coverage requirement

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -18,7 +18,7 @@ npm run preview  # preview the build
 npm test         # run unit tests once
 ```
 
-`npm run build` executes the tests first and fails if coverage is below **90%**.
+`npm run build` executes the tests first and fails if coverage is below **60%**.
 
 ## File Structure
 - `index.html` – entry page

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -11,10 +11,7 @@ export function setupRotation(element: HTMLElement): void {
   });
 }
 
-/* c8 ignore next */
 const croissant = document.getElementById('croissant');
-/* c8 ignore next */
 if (croissant) {
-  /* c8 ignore next */
-  setupRotation(croissant);
+    setupRotation(croissant);
 }

--- a/example/vitest.config.ts
+++ b/example/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     environment: 'jsdom',
     coverage: {
       provider: 'v8',
-      thresholds: { lines: 90 }
+      thresholds: { lines: 60 }
     }
   }
 });

--- a/practices/CODING_RULES.md
+++ b/practices/CODING_RULES.md
@@ -33,7 +33,7 @@ This document defines the lifecycle that all contributors must follow. It applie
 - Aim for robust coverage to prevent regressions.
 
 ## 8. Quality Gates
-- Automated tests must achieve at least **90% line coverage**.
+- Automated tests must achieve at least **60% line coverage**.
 - The default build will fail if this threshold is not met.
 
 ## 9. Refactor with Confidence

--- a/practices/FEATURE.md
+++ b/practices/FEATURE.md
@@ -5,7 +5,7 @@ When introducing a new feature, follow these principles:
 1. **Test-Driven Development**
    - Write unit and integration tests first to describe the desired behaviour.
    - Do not implement functionality until failing tests prove the need.
-   - Aim for at least 90% coverage as described in [Testing](TESTING.md).
+   - Aim for at least 60% coverage as described in [Testing](TESTING.md).
    - Provide an end-to-end test for each user-facing capability. See the
      [Testing practices](TESTING.md) section on E2E tests.
 2. **Documentation**

--- a/practices/TESTING.md
+++ b/practices/TESTING.md
@@ -4,7 +4,7 @@ This repository follows a test-driven approach. Every feature begins with tests 
 
 ## Unit Tests
 - All logic should be unit tested.
-- We target **90% line coverage** as a quality gate.
+- We target **60% line coverage** as a quality gate.
 - The default build fails if coverage drops below this threshold.
 
 ## Integration Tests

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -27,7 +27,7 @@ npm run test:perf # run manual performance benchmarks
 
 The entry page `index.html` mounts `src/main.tsx`. Core physics logic lives in `src/physics/`, the Preact components in `src/components/` and scenarios in `src/scenarios/`.
 
-The build script runs the test suite first and fails if unit test coverage drops below **90%**.
+The build script runs the test suite first and fails if unit test coverage drops below **60%**.
 
 `npm run test:perf` measures physics and renderer performance. The benchmarks are manual only and help track how many bodies we can simulate or draw at acceptable frame rates.
 

--- a/spacesim/docs/1/example/README.md
+++ b/spacesim/docs/1/example/README.md
@@ -18,7 +18,7 @@ npm run preview  # preview the build
 npm test         # run unit tests once
 ```
 
-`npm run build` executes the tests first and fails if coverage is below **90%**.
+`npm run build` executes the tests first and fails if coverage is below **60%**.
 
 ## File Structure
 - `index.html` – entry page

--- a/spacesim/docs/1/generated.json
+++ b/spacesim/docs/1/generated.json
@@ -2,5 +2,5 @@
   "version": "1.0.0",
   "minor": 0,
   "patch": 0,
-  "timestamp": 1753270330147
+  "timestamp": 1753272513744
 }

--- a/spacesim/docs/1/practices/CODING_RULES.md
+++ b/spacesim/docs/1/practices/CODING_RULES.md
@@ -33,7 +33,7 @@ This document defines the lifecycle that all contributors must follow. It applie
 - Aim for robust coverage to prevent regressions.
 
 ## 8. Quality Gates
-- Automated tests must achieve at least **90% line coverage**.
+- Automated tests must achieve at least **60% line coverage**.
 - The default build will fail if this threshold is not met.
 
 ## 9. Refactor with Confidence

--- a/spacesim/docs/1/practices/FEATURE.md
+++ b/spacesim/docs/1/practices/FEATURE.md
@@ -5,7 +5,7 @@ When introducing a new feature, follow these principles:
 1. **Test-Driven Development**
    - Write unit and integration tests first to describe the desired behaviour.
    - Do not implement functionality until failing tests prove the need.
-   - Aim for at least 90% coverage as described in [Testing](TESTING.md).
+   - Aim for at least 60% coverage as described in [Testing](TESTING.md).
    - Provide an end-to-end test for each user-facing capability. See the
      [Testing practices](TESTING.md) section on E2E tests.
 2. **Documentation**

--- a/spacesim/docs/1/practices/TESTING.md
+++ b/spacesim/docs/1/practices/TESTING.md
@@ -4,7 +4,7 @@ This repository follows a test-driven approach. Every feature begins with tests 
 
 ## Unit Tests
 - All logic should be unit tested.
-- We target **90% line coverage** as a quality gate.
+- We target **60% line coverage** as a quality gate.
 - The default build fails if coverage drops below this threshold.
 
 ## Integration Tests

--- a/spacesim/docs/1/spacesim/README.md
+++ b/spacesim/docs/1/spacesim/README.md
@@ -27,7 +27,7 @@ npm run test:perf # run manual performance benchmarks
 
 The entry page `index.html` mounts `src/main.tsx`. Core physics logic lives in `src/physics/`, the Preact components in `src/components/` and scenarios in `src/scenarios/`.
 
-The build script runs the test suite first and fails if unit test coverage drops below **90%**.
+The build script runs the test suite first and fails if unit test coverage drops below **60%**.
 
 `npm run test:perf` measures physics and renderer performance. The benchmarks are manual only and help track how many bodies we can simulate or draw at acceptable frame rates.
 

--- a/spacesim/vitest.config.ts
+++ b/spacesim/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 
     coverage: {
       provider: 'v8',
-      thresholds: { lines: 90 },
+      thresholds: { lines: 60 },
       exclude: [
         'src/components/**',
         'src/*.tsx',


### PR DESCRIPTION
## Summary
- drop c8 ignore comments in the example app
- lower coverage thresholds from 90% to 60%
- regenerate docs with new threshold

## Testing
- `node test/generate-docs.test.js`
- `node test/new-record.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6880cfc4d4a08320b13f45043ae6821b