### PR TITLE
Fix DocsView test cleanup

### DIFF
--- a/spacesim/src/components/docsView.test.tsx
+++ b/spacesim/src/components/docsView.test.tsx
@@ -5,6 +5,7 @@ import DocsView from './DocsView';
 const originalFetch = global.fetch;
 
 afterEach(() => {
+  document.body.innerHTML = '';
   global.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- clear document body after running DocsView tests so leftover elements don't interfere with later tests

## Testing
- `npm test` in `spacesim`

------
https://chatgpt.com/codex/tasks/task_e_6880d36323ec832094782ef4048cde8c