### PR TITLE
feat: add scenario view

### DIFF
--- a/feature/README.md
+++ b/feature/README.md
@@ -17,5 +17,6 @@ Create a folder here for each significant feature. Document:
 - [3D Renderer](three-renderer/README.md)
 - [Zoom, Pan and Center View](zoom-pan/README.md)
 - [Performance Tests](performance-tests/README.md)
+- [Scenario View](scenario-view/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/scenario-view/README.md
+++ b/feature/scenario-view/README.md
@@ -1,0 +1,12 @@
+# Scenario View
+
+A dedicated tab plays predefined scenarios.
+The first implementation loads a hardcoded Solar System simulation where all planets spawn automatically.
+
+- `ScenarioView` wraps `Simulation` with the `solarSystem` events.
+- Switching to the **Scenario** tab loads the scenario and runs it immediately.
+- Covered by unit and end-to-end tests.
+
+## Tests
+- `spacesim/src/simulation.test.ts`
+- `spacesim/e2e/scenario.spec.ts`

--- a/spacesim/docs/1/README.md
+++ b/spacesim/docs/1/README.md
@@ -10,7 +10,7 @@ A detailed workflow for all contributors is defined in [`practices/CODING_RULES.
 
 This file is part of the initial project scaffolding and will evolve as the project grows.
 
- ## Features
+## Features
 
 Implemented features are documented under the [feature/](feature/) directory. Each entry links to the commits and has an accompanying end-to-end test.
 

--- a/spacesim/docs/1/feature/README.md
+++ b/spacesim/docs/1/feature/README.md
@@ -15,5 +15,8 @@ Create a folder here for each significant feature. Document:
 - [Orbit overlays](orbit-overlay/README.md)
 - [Simulation Speed Control](speed-control/README.md)
 - [3D Renderer](three-renderer/README.md)
+- [Zoom, Pan and Center View](zoom-pan/README.md)
+- [Performance Tests](performance-tests/README.md)
+- [Scenario View](scenario-view/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/spacesim/docs/1/feature/body-editor/README.md
+++ b/spacesim/docs/1/feature/body-editor/README.md
@@ -8,4 +8,7 @@ Clicking an existing body opens a panel to inspect and edit its data.
 - The editor stays open after applying and closes when you click elsewhere.
 - `Simulation` emits a `bodyUpdate` event whenever changes are applied.
 - Implemented in `spacesim`.
-- End-to-end coverage: `spacesim/e2e/edit.spec.ts`.
+
+## Tests
+- `spacesim/e2e/edit.spec.ts`
+- `spacesim/src/physics.test.ts`

--- a/spacesim/docs/1/feature/drag-spawn/README.md
+++ b/spacesim/docs/1/feature/drag-spawn/README.md
@@ -7,4 +7,7 @@ Dragging on the canvas spawns a new body. The drag distance and direction determ
 - The body is created on mouse release using the parameters from the spawner panel and a unique label.
 - Clicking an existing body selects it instead of starting a drag.
 - Implemented in `spacesim`.
-- End-to-end coverage: `spacesim/e2e/spawn.spec.ts`.
+
+## Tests
+- `spacesim/e2e/spawn.spec.ts`
+- `spacesim/src/throwVelocity.test.ts`

--- a/spacesim/docs/1/feature/orbit-overlay/README.md
+++ b/spacesim/docs/1/feature/orbit-overlay/README.md
@@ -5,3 +5,8 @@ Active bodies display a dotted line predicting their orbit.
 - `ThreeRenderer` now simulates each body around the most massive one and draws the path using dashed Three.js lines.
 - Lines use the body's color but turn **blue** on escape trajectories and **red** when doomed to crash.
 - Unit tests cover the color logic in `src/threeRenderer.test.ts`.
+
+## Tests
+- `spacesim/src/overlayRenderer.test.ts`
+- `spacesim/src/threeRenderer.test.ts`
+- `spacesim/src/predictOrbitType.test.ts`

--- a/spacesim/docs/1/feature/pause-reset/README.md
+++ b/spacesim/docs/1/feature/pause-reset/README.md
@@ -5,4 +5,8 @@ The toolbar at the top right provides **Pause** and **Reset** buttons.
 - **Pause** stops the game loop and the button text toggles to **Start**.
 - **Reset** removes all bodies, clears any drag line and current selection.
 - Implemented in `spacesim`.
-- End-to-end coverage: `spacesim/e2e/controls.spec.ts`.
+
+## Tests
+- `spacesim/e2e/controls.spec.ts`
+- `spacesim/src/core/gameLoop.test.ts`
+- `spacesim/src/physics.test.ts`

--- a/spacesim/docs/1/feature/scenario-view/README.md
+++ b/spacesim/docs/1/feature/scenario-view/README.md
@@ -1,0 +1,12 @@
+# Scenario View
+
+A dedicated tab plays predefined scenarios.
+The first implementation loads a hardcoded Solar System simulation where all planets spawn automatically.
+
+- `ScenarioView` wraps `Simulation` with the `solarSystem` events.
+- Switching to the **Scenario** tab loads the scenario and runs it immediately.
+- Covered by unit and end-to-end tests.
+
+## Tests
+- `spacesim/src/simulation.test.ts`
+- `spacesim/e2e/scenario.spec.ts`

--- a/spacesim/docs/1/feature/select-highlight/README.md
+++ b/spacesim/docs/1/feature/select-highlight/README.md
@@ -5,3 +5,6 @@ The list of bodies now visually marks which entry is selected.
 - `BodyList` accepts a `selected` prop and applies a darker background to that entry.
 - `Simulation` forwards the current selection to the list.
 - A component test ensures the selected item is highlighted.
+
+## Tests
+- `spacesim/src/components/bodyList.test.tsx`

--- a/spacesim/docs/1/feature/speed-control/README.md
+++ b/spacesim/docs/1/feature/speed-control/README.md
@@ -5,5 +5,8 @@ The simulation toolbar now lets users change how fast physics runs.
 - `Simulation` tracks a speed multiplier (1–64) and scales the timestep.
 - New buttons «««, xN and »»» adjust or reset the speed.
 - Rendering stays fixed at 25 fps.
-- Covered by unit tests in `src/simulation.test.ts` and e2e in `e2e/controls.spec.ts`.
+
+## Tests
+- `spacesim/src/simulation.test.ts`
+- `spacesim/e2e/controls.spec.ts`
 

--- a/spacesim/docs/1/feature/three-renderer/README.md
+++ b/spacesim/docs/1/feature/three-renderer/README.md
@@ -3,3 +3,6 @@
 The simulation now draws bodies using [Three.js](https://threejs.org/). A new `ThreeRenderer` replaces the previous canvas based renderer. Spheres are synced with the physics engine each frame and rendered via an orthographic camera. Overlay elements like predicted orbits and the drag vector are also drawn with Three.js lines.
 
 Related commits document the implementation and accompanying unit test.
+
+## Tests
+- `spacesim/src/threeRenderer.test.ts`

--- a/spacesim/docs/1/feature/zoom-pan/README.md
+++ b/spacesim/docs/1/feature/zoom-pan/README.md
@@ -7,3 +7,7 @@ The simulation view can be zoomed, panned and centered on a body.
 - `CanvasView` converts mouse coordinates using `screenToWorld`.
 - Toolbar controls allow zooming with +/-, panning with arrows and centering on the selected body.
 - Documented in this feature and covered by unit tests in `src/view.test.ts`.
+
+## Tests
+- `spacesim/src/view.test.ts`
+- `spacesim/e2e/view.spec.ts`

--- a/spacesim/docs/1/generated.json
+++ b/spacesim/docs/1/generated.json
@@ -2,5 +2,5 @@
   "version": "1.0.0",
   "minor": 0,
   "patch": 0,
-  "timestamp": 1753272513744
+  "timestamp": 1753275179481
 }

--- a/spacesim/docs/1/manifest.json
+++ b/spacesim/docs/1/manifest.json
@@ -16,6 +16,7 @@
     "feature/orbit-overlay/README.md",
     "feature/pause-reset/README.md",
     "feature/performance-tests/README.md",
+    "feature/scenario-view/README.md",
     "feature/select-highlight/README.md",
     "feature/speed-control/README.md",
     "feature/three-renderer/README.md",

--- a/spacesim/e2e/scenario.spec.ts
+++ b/spacesim/e2e/scenario.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('scenario tab spawns solar system', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Scenario' }).click();
+  await page.getByRole('button', { name: 'Pause' }).waitFor();
+  await page.waitForTimeout(500);
+  const count = await page.evaluate(() => window.sim.bodies.length);
+  expect(count).toBeGreaterThan(5);
+});

--- a/spacesim/src/components/Root.tsx
+++ b/spacesim/src/components/Root.tsx
@@ -1,14 +1,6 @@
 import { useState } from 'preact/hooks';
-import CanvasView from './CanvasView';
-import BodyList from './BodyList';
-import BodyEditor from './BodyEditor';
-import BodySpawner from './BodySpawner';
-import { Simulation } from '../simulation';
-import { Vec2 } from 'planck-js';
-import { solarSystem } from '../scenarios/solarSystem';
-import { uniqueName } from '../utils';
-
 import SimulationView from './Simulation';
+import ScenarioView from './ScenarioView';
 import DocsView from './DocsView';
 
 export default function Root() {
@@ -21,7 +13,7 @@ export default function Root() {
         <button onClick={() => setTab('scenario')}>Scenario</button>
         <button onClick={() => setTab('docs')}>Docs</button>
       </div>
-      {tab === 'sandbox' ? <SimulationView /> : tab === 'docs' ? <DocsView /> : <div style={{color:'#fff'}}>Scenario coming soon</div>}
+      {tab === 'sandbox' ? <SimulationView /> : tab === 'scenario' ? <ScenarioView /> : <DocsView />}
     </div>
   );
 }

--- a/spacesim/src/components/ScenarioView.tsx
+++ b/spacesim/src/components/ScenarioView.tsx
@@ -1,0 +1,6 @@
+import SimulationView from './Simulation';
+import { solarSystem } from '../scenarios/solarSystem';
+
+export default function ScenarioView() {
+  return <SimulationView scenario={solarSystem} />;
+}

--- a/spacesim/src/scenarios/solarSystem.ts
+++ b/spacesim/src/scenarios/solarSystem.ts
@@ -12,6 +12,20 @@ export const solarSystem: ScenarioEvent[] = [
   {
     time: 0.1,
     action: 'addBody',
+    position: Vec2(40, 0),
+    velocity: Vec2(0, 4.8),
+    data: { mass: 0.055, radius: 1, color: 'gray', label: 'Mercury' }
+  },
+  {
+    time: 0.1,
+    action: 'addBody',
+    position: Vec2(70, 0),
+    velocity: Vec2(0, 3.5),
+    data: { mass: 0.815, radius: 2, color: 'orange', label: 'Venus' }
+  },
+  {
+    time: 0.1,
+    action: 'addBody',
     position: Vec2(100, 0),
     velocity: Vec2(0, 3),
     data: { mass: 1, radius: 4, color: 'blue', label: 'Earth' }
@@ -20,7 +34,35 @@ export const solarSystem: ScenarioEvent[] = [
     time: 0.1,
     action: 'addBody',
     position: Vec2(150, 0),
-    velocity: Vec2(0, 2.5),
-    data: { mass: 0.1, radius: 2, color: 'gray', label: 'Mars' }
+    velocity: Vec2(0, 2.4),
+    data: { mass: 0.107, radius: 2, color: 'red', label: 'Mars' }
+  },
+  {
+    time: 0.2,
+    action: 'addBody',
+    position: Vec2(300, 0),
+    velocity: Vec2(0, 1.5),
+    data: { mass: 317.8, radius: 6, color: 'orange', label: 'Jupiter' }
+  },
+  {
+    time: 0.2,
+    action: 'addBody',
+    position: Vec2(400, 0),
+    velocity: Vec2(0, 1.2),
+    data: { mass: 95, radius: 5, color: 'gold', label: 'Saturn' }
+  },
+  {
+    time: 0.2,
+    action: 'addBody',
+    position: Vec2(500, 0),
+    velocity: Vec2(0, 1),
+    data: { mass: 14, radius: 4, color: 'lightblue', label: 'Uranus' }
+  },
+  {
+    time: 0.2,
+    action: 'addBody',
+    position: Vec2(600, 0),
+    velocity: Vec2(0, 0.8),
+    data: { mass: 17, radius: 4, color: 'blue', label: 'Neptune' }
   }
 ];

--- a/spacesim/src/simulation.test.ts
+++ b/spacesim/src/simulation.test.ts
@@ -6,9 +6,9 @@ describe('Simulation scenarios', () => {
   it('loads scenario and spawns bodies over time', () => {
     const sim = new Simulation();
     sim.loadScenario(solarSystem);
-    // run steps enough to process scenario events
-    for (let i = 0; i < 10; i++) sim['step'](0.1); // using private method access for test
-    expect(sim.bodies.length).toBeGreaterThan(1);
+    // run steps enough to process all scenario events
+    for (let i = 0; i < 30; i++) sim['step'](0.1); // using private method access for test
+    expect(sim.bodies.length).toBe(solarSystem.length);
   });
 
   it('scales timestep with speed multiplier', () => {


### PR DESCRIPTION
## Summary
- implement ScenarioView component and hook up tab
- expand solarSystem scenario to spawn all planets
- test scenario events spawning
- add e2e check for scenario tab
- document Scenario View feature
- regenerate docs

## Testing
- `npm test`
- `npx playwright install`
- `npx playwright install-deps`
- `npm run test:e2e`
- `node scripts/generate-docs.js`

------
https://chatgpt.com/codex/tasks/task_e_6880d97132ac8320802f5c4bdb20f6cb