### PR TITLE
fix: stabilise orbits using sphere of influence

### DIFF
--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -14,6 +14,16 @@ describe('Sandbox gravity', () => {
     expect(b.body.getLinearVelocity().x).toBeLessThan(0);
   });
 
+  it('does not accelerate heavier body', () => {
+    const sb = new PhysicsEngine();
+    const heavy = sb.addBody(Vec2(0, 0), Vec2(), { mass: 5, radius: 1, color: 'red', label: '' });
+    sb.addBody(Vec2(10, 0), Vec2(), { mass: 1, radius: 1, color: 'blue', label: '' });
+
+    sb.step(1 / 60);
+    const vel = heavy.body.getLinearVelocity();
+    expect(vel.length()).toBeCloseTo(0);
+  });
+
   it('clears bodies on reset', () => {
     const sb = new PhysicsEngine();
     sb.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: '' });

--- a/spacesim/src/physics/engine.ts
+++ b/spacesim/src/physics/engine.ts
@@ -85,18 +85,31 @@ export class PhysicsEngine {
 
   private applyGravity() {
     for (let i = 0; i < this.bodies.length; i++) {
-      for (let j = i + 1; j < this.bodies.length; j++) {
-        const a = this.bodies[i];
-        const b = this.bodies[j];
-        const posA = a.body.getPosition();
-        const posB = b.body.getPosition();
-        const r = Vec2.sub(posB, posA);
+      const child = this.bodies[i];
+      let parent: { body: planck.Body; data: BodyData } | undefined;
+      let bestPull = 0;
+      for (let j = 0; j < this.bodies.length; j++) {
+        if (i === j) continue;
+        const candidate = this.bodies[j];
+        if (candidate.data.mass < child.data.mass) continue;
+        const rVec = Vec2.sub(candidate.body.getPosition(), child.body.getPosition());
+        const distSq = rVec.lengthSquared();
+        if (distSq === 0) continue;
+        const pull = candidate.data.mass / distSq;
+        if (pull > bestPull) {
+          bestPull = pull;
+          parent = candidate;
+        }
+      }
+      if (parent) {
+        const posChild = child.body.getPosition();
+        const posParent = parent.body.getPosition();
+        const r = Vec2.sub(posParent, posChild);
         const distSq = r.lengthSquared();
         if (distSq === 0) continue;
-        const forceMag = (G * a.data.mass * b.data.mass) / distSq;
-        const force = r.clone().mul(forceMag / Math.sqrt(distSq));
-        a.body.applyForceToCenter(force, true);
-        b.body.applyForceToCenter(force.neg(), true);
+        const forceMag = (G * child.data.mass * parent.data.mass) / distSq;
+        const force = r.mul(forceMag / Math.sqrt(distSq));
+        child.body.applyForceToCenter(force, true);
       }
     }
   }


### PR DESCRIPTION
## Summary
- update gravity calculation to only move lighter bodies toward heavier parents
- verify heavy bodies remain unaffected by smaller ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880ddbdc8cc83209b46b17fb2960717