### PR TITLE
Fix orbit drift by enabling engine sub-steps

### DIFF
--- a/bugfix/orbit-substeps/README.md
+++ b/bugfix/orbit-substeps/README.md
@@ -1,0 +1,14 @@
+# Orbit drift with single substep
+
+## Issue
+The energy-drift fix introduced sub-stepping in `PhysicsEngine`, but the `Simulation` class still instantiated the engine with the default single substep. In long-running scenarios orbital energy slowly increased and bodies drifted away.
+
+## Root cause
+`Simulation` created `new PhysicsEngine()` which defaults to `subSteps = 1`. The integration error of Planck.js accumulates with such a large step.
+
+## Fix
+`Simulation` now constructs `PhysicsEngine(5)` so each tick is divided into five substeps. A regression test verifies that energy differs significantly when only one substep is used.
+
+## References
+- commit implementing the fix
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/src/energyDrift.test.ts
+++ b/spacesim/src/energyDrift.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { PhysicsEngine, G } from './physics';
+import { Vec2 } from 'planck-js';
+
+function systemEnergy(a: { body: any; data: any }, b: { body: any; data: any }) {
+  const posA = a.body.getPosition();
+  const posB = b.body.getPosition();
+  const velA = a.body.getLinearVelocity();
+  const velB = b.body.getLinearVelocity();
+  const r = posA.clone().sub(posB).length();
+  const keA = 0.5 * a.data.mass * velA.lengthSquared();
+  const keB = 0.5 * b.data.mass * velB.lengthSquared();
+  const pe = -(G * a.data.mass * b.data.mass) / r;
+  return keA + keB + pe;
+}
+
+describe('energy drift', () => {
+  it('drifts when using a single substep', () => {
+    const engine = new PhysicsEngine();
+    const sun = engine.addBody(Vec2(0, 0), Vec2(), { mass: 1000, radius: 10, color: 'yellow', label: 'Sun' });
+    const earth = engine.addBody(Vec2(100, 0), Vec2(0, 3), { mass: 1, radius: 4, color: 'blue', label: 'Earth' });
+    const initial = systemEnergy(earth, sun);
+    for (let i = 0; i < 500; i++) engine.step(0.04);
+    const final = systemEnergy(earth, sun);
+    expect(Math.abs(final - initial)).toBeGreaterThan(0.1);
+  });
+});

--- a/spacesim/src/simulation.ts
+++ b/spacesim/src/simulation.ts
@@ -20,7 +20,8 @@ interface Events {
 }
 
 export class Simulation {
-  private engine = new PhysicsEngine();
+  // use multiple substeps to keep orbits stable
+  private engine = new PhysicsEngine(5);
   private bus: EventBus<Events> = createEventBus<Events>();
   private loop = new GameLoop(this.bus, 1 / 25);
   private renderer?: ThreeRenderer;


### PR DESCRIPTION
## Summary
- add regression test capturing energy drift with only one substep
- instantiate `PhysicsEngine` with five substeps in `Simulation`
- document the fix under `bugfix/orbit-substeps`

## Testing
- `npm test` in `spacesim`

------
https://chatgpt.com/codex/tasks/task_e_6880e92170ec832085da66c5b91f36c6