### PR TITLE
feat: expose mouse event callbacks in CanvasView

### DIFF
--- a/spacesim/src/components/CanvasView.tsx
+++ b/spacesim/src/components/CanvasView.tsx
@@ -5,7 +5,12 @@ import { Vec2 } from 'planck-js';
 interface Props {
   sim: Simulation;
   onClick?: (pos: Vec2) => void;
+  onMouseDown?: (pos: Vec2) => void;
+  onMouseMove?: (pos: Vec2) => void;
+  onMouseUp?: (pos: Vec2) => void;
 }
+
+import { JSX } from 'preact';
 
 export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onMouseUp }: Props) {
   const ref = useRef<HTMLCanvasElement>(null);
@@ -17,8 +22,8 @@ export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onM
     canvas.height = canvas.clientHeight * dpr;
     sim.setCanvas(canvas);
   }, [sim]);
-  const toVec = (e: MouseEvent) => {
-    const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
+  const toVec = (e: JSX.TargetedMouseEvent<HTMLCanvasElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
     const p = Vec2(
       (e.clientX - rect.left) * dpr,
@@ -26,19 +31,19 @@ export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onM
     );
     return sim.screenToWorld(p);
   };
-  const handleClick = (e: MouseEvent) => {
-    if (onClick) onClick(toVec(e));
+  const handleClick: JSX.MouseEventHandler<HTMLCanvasElement> = e => {
+    onClick?.(toVec(e));
   };
-  const handleDown = (e: MouseEvent) => onMouseDown?.(toVec(e));
-  const handleMove = (e: MouseEvent) => onMouseMove?.(toVec(e));
-  const handleUp = (e: MouseEvent) => onMouseUp?.(toVec(e));
+  const handleDown: JSX.MouseEventHandler<HTMLCanvasElement> = e => onMouseDown?.(toVec(e));
+  const handleMove: JSX.MouseEventHandler<HTMLCanvasElement> = e => onMouseMove?.(toVec(e));
+  const handleUp: JSX.MouseEventHandler<HTMLCanvasElement> = e => onMouseUp?.(toVec(e));
   return (
     <canvas
       ref={ref}
-      onClick={handleClick as any}
-      onMouseDown={handleDown as any}
-      onMouseMove={handleMove as any}
-      onMouseUp={handleUp as any}
+      onClick={handleClick}
+      onMouseDown={handleDown}
+      onMouseMove={handleMove}
+      onMouseUp={handleUp}
       style={{ width: '100%', height: '100%' }}
     />
   );

--- a/spacesim/src/components/canvasView.test.tsx
+++ b/spacesim/src/components/canvasView.test.tsx
@@ -37,4 +37,28 @@ describe('CanvasView', () => {
     expect(arg.y).toBeCloseTo(30);
     Object.defineProperty(window, 'devicePixelRatio', { value: orig });
   });
+
+  it('calls optional mouse handlers with world coordinates', () => {
+    const down = vi.fn();
+    const move = vi.fn();
+    const up = vi.fn();
+    const sim = { setCanvas: vi.fn(), screenToWorld: (v: Vec2) => v } as any;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(
+      <CanvasView sim={sim} onMouseDown={down} onMouseMove={move} onMouseUp={up} />,
+      container
+    );
+    const canvas = container.querySelector('canvas')!;
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 100, height: 100 } as any);
+    canvas.dispatchEvent(new MouseEvent('mousedown', { clientX: 1, clientY: 2 }));
+    canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: 3, clientY: 4 }));
+    canvas.dispatchEvent(new MouseEvent('mouseup', { clientX: 5, clientY: 6 }));
+    expect((down.mock.calls[0][0] as ReturnType<typeof Vec2>).x).toBeCloseTo(1);
+    expect((down.mock.calls[0][0] as ReturnType<typeof Vec2>).y).toBeCloseTo(2);
+    expect((move.mock.calls[0][0] as ReturnType<typeof Vec2>).x).toBeCloseTo(3);
+    expect((move.mock.calls[0][0] as ReturnType<typeof Vec2>).y).toBeCloseTo(4);
+    expect((up.mock.calls[0][0] as ReturnType<typeof Vec2>).x).toBeCloseTo(5);
+    expect((up.mock.calls[0][0] as ReturnType<typeof Vec2>).y).toBeCloseTo(6);
+  });
 });


### PR DESCRIPTION
## Summary
- extend CanvasView props with optional mouse callbacks
- remove `as any` casts and use proper Preact event types
- test mouse handlers on CanvasView

## Testing
- `npm test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68811f2837a883209eb4590c180c5e0a