### PR TITLE
Fix window leak in simulation component

### DIFF
--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -16,7 +16,10 @@ interface Props {
 export default function SimulationComponent({ scenario, sim: ext }: Props) {
   const [sim] = useState(() => ext ?? new Simulation());
   useEffect(() => {
-    (window as any).sim = sim;
+    if (import.meta.env.DEV) {
+      (window as any).sim = sim;
+      return () => { delete (window as any).sim; };
+    }
   }, [sim]);
   const [running, setRunning] = useState(true);
   const [selected, setSelected] = useState<ReturnType<Simulation['addBody']> | null>(null);

--- a/spacesim/src/components/simulationComponent.test.tsx
+++ b/spacesim/src/components/simulationComponent.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { render } from 'preact'
+import SimulationComponent from './Simulation'
+
+const sim = {
+  onRender: () => () => {},
+  start: () => {},
+  stop: () => {},
+  loadScenario: () => {},
+  speed: 1,
+  bodies: [],
+  view: { zoom: 1, center: { x: 0, y: 0 } },
+  findBody: () => null,
+  setOverlay: () => {},
+  setCanvas: () => {},
+  addBody: () => ({ body: {}, data: {} }),
+  pan: () => {},
+  zoom: () => {},
+  centerOn: () => {},
+  reset: () => {},
+  resetView: () => {},
+  speedUp: () => {},
+  slowDown: () => {},
+  resetSpeed: () => {}
+} as any
+
+describe('SimulationComponent', () => {
+  it('exposes sim on window in dev', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    expect((window as any).sim).toBeUndefined()
+    render(<SimulationComponent sim={sim} />, container)
+    await new Promise(r => setTimeout(r, 20))
+    expect((window as any).sim).toBe(sim)
+  })
+})


### PR DESCRIPTION
## Summary
- guard global `window.sim` with a dev check
- add test verifying the global is set in development

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811f4bcc608320b2ae310dddd92b67