### PR TITLE
Add root test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  root:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,19 +14,6 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - run: node test/new-record.test.js && node test/generate-docs.test.js
-
-  spacesim:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: spacesim
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 20
-      - run: npm install
+      - run: npm --prefix spacesim install
+      - run: npx --prefix spacesim playwright install --with-deps
       - run: npm test
-      - run: npx playwright install --with-deps
-      - run: npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ Implemented features are documented under the [feature/](feature/) directory. Ea
 All Markdown files in the repository can be compiled into a browsable set of docs.
 Run `npm run docs` at the repository root to regenerate them. The output appears
 under `spacesim/docs/<major>` based on the package version.
+
+## Testing
+
+Run `npm test` to execute every test suite. This runs the Node scripts in
+`test/`, then launches the Spacesim unit tests with coverage, its end-to-end
+browser checks and the performance benchmarks.
+The GitHub Actions workflow calls the same command and merges are blocked if any
+test fails.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Welcome to Codex2! This repository is scaffolded using **documentation-driven development**. Directories include `README.md` and `AGENTS.md` only when they add context beyond what parent folders describe. These documents help both human developers and AI coding agents understand the structure, intent, and rules of the codebase.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/generate-docs.test.js && node test/new-record.test.js && node scripts/generate-docs.js && npm --prefix spacesim test && npm --prefix spacesim run test:e2e && npm --prefix spacesim run test:perf",
     "lint:commit": "commitlint --edit",
     "docs": "node scripts/generate-docs.js"
   },


### PR DESCRIPTION
## Summary
- set up root `npm test` to run repo and spacesim suites
- note the command in README

## Testing
- `npm test` *(fails: spacesim e2e `edit body label`)*

------
https://chatgpt.com/codex/tasks/task_e_68811f3ca560832094293abd4629e7c5