### PR TITLE
Update root guidance with npm proxy note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,6 @@ Welcome, coding agent! Follow these instructions whenever you work in this repos
    - Some subfolders include their own `AGENTS.md` with additional guidance. If present, read it before editing files in that folder.
 
 These practices must not be altered without explicit approval. Raise concerns rather than modifying them silently.
+
+## Environment Note
+If `npm test` prints `npm warn Unknown env config "http-proxy"`, the environment has `npm_config_http_proxy` or `npm_config_https_proxy` set. Unset these variables (or use the newer `npm_config_proxy` names) to silence the warning.

--- a/spacesim/docs/1/AGENTS.md
+++ b/spacesim/docs/1/AGENTS.md
@@ -14,3 +14,6 @@ Welcome, coding agent! Follow these instructions whenever you work in this repos
    - Some subfolders include their own `AGENTS.md` with additional guidance. If present, read it before editing files in that folder.
 
 These practices must not be altered without explicit approval. Raise concerns rather than modifying them silently.
+
+## Environment Note
+If `npm test` prints `npm warn Unknown env config "http-proxy"`, the environment has `npm_config_http_proxy` or `npm_config_https_proxy` set. Unset these variables (or use the newer `npm_config_proxy` names) to silence the warning.

--- a/spacesim/docs/1/README.md
+++ b/spacesim/docs/1/README.md
@@ -19,3 +19,11 @@ Implemented features are documented under the [feature/](feature/) directory. Ea
 All Markdown files in the repository can be compiled into a browsable set of docs.
 Run `npm run docs` at the repository root to regenerate them. The output appears
 under `spacesim/docs/<major>` based on the package version.
+
+## Testing
+
+Run `npm test` to execute every test suite. This runs the Node scripts in
+`test/`, then launches the Spacesim unit tests with coverage, its end-to-end
+browser checks and the performance benchmarks.
+The GitHub Actions workflow calls the same command and merges are blocked if any
+test fails.

--- a/spacesim/docs/1/bugfix/variable-dt/README.md
+++ b/spacesim/docs/1/bugfix/variable-dt/README.md
@@ -1,0 +1,14 @@
+# Physics time drift
+
+## Issue
+Orbital paths slowly diverged from expectations during long runs. The physics engine stepped using a fixed `dt`, but tick events arrived at inconsistent real-time intervals. Each step projected the world forward by the same amount of time regardless of how long actually passed.
+
+## Root cause
+`GameLoop` emitted a constant timestep to the simulation while real elapsed time varied. When frames were delayed the engine effectively skipped time, producing unrealistic orbits.
+
+## Fix
+`GameLoop` now tracks the last tick timestamp and calculates `dt` from the real elapsed time using `Date.now()`. The physics engine therefore advances by the exact amount of time that passed since the previous update.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/docs/1/generated.json
+++ b/spacesim/docs/1/generated.json
@@ -2,5 +2,5 @@
   "version": "1.0.0",
   "minor": 0,
   "patch": 0,
-  "timestamp": 1753275179481
+  "timestamp": 1753294634852
 }

--- a/spacesim/docs/1/manifest.json
+++ b/spacesim/docs/1/manifest.json
@@ -10,6 +10,7 @@
     "bugfix/label-position-offset/README.md",
     "bugfix/overlay-color/README.md",
     "bugfix/three-renderer-fixes/README.md",
+    "bugfix/variable-dt/README.md",
     "feature/README.md",
     "feature/body-editor/README.md",
     "feature/drag-spawn/README.md",


### PR DESCRIPTION
## Summary
- add a tip in `AGENTS.md` about the `http-proxy` warning when running npm
- regenerate documentation to reflect new guidance

## Testing
- `npm test` *(fails: Playwright browsers missing)*
- `npm run docs`

------
https://chatgpt.com/codex/tasks/task_e_6881238b81b48320a7df2fdaec778e5b