### PR TITLE
Record benchmark results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 coverage/
 **/coverage/
 spacesim/test-results/
+spacesim/performance/latest.json
+spacesim/performance/results.json

--- a/feature/README.md
+++ b/feature/README.md
@@ -17,6 +17,7 @@ Create a folder here for each significant feature. Document:
 - [3D Renderer](three-renderer/README.md)
 - [Zoom, Pan and Center View](zoom-pan/README.md)
 - [Performance Tests](performance-tests/README.md)
+- [Performance History](perf-history/README.md)
 - [Scenario View](scenario-view/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/perf-history/README.md
+++ b/feature/perf-history/README.md
@@ -1,0 +1,7 @@
+# Performance History
+
+Benchmark runs now save their results so we can track performance over time.
+After running `npm run test:perf` inside `spacesim`, a `latest.json` file
+is written to `spacesim/performance` and compared against `results.json`.
+If any benchmark runs slower than the previous result, a warning is printed.
+When no slowdown is detected, the baseline `results.json` is updated.

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -25,6 +25,11 @@ npm run test:e2e  # run browser tests with Playwright
 npm run test:perf # run manual performance benchmarks
 ```
 
+Playwright requires browser binaries. If tests fail complaining about missing browsers, run:
+```bash
+npx playwright install --with-deps
+```
+
 The entry page `index.html` mounts `src/main.tsx`. Core physics logic lives in `src/physics/`, the Preact components in `src/components/` and scenarios in `src/scenarios/`.
 
 The build script runs the test suite first and fails if unit test coverage drops below **60%**.

--- a/spacesim/docs/1/feature/perf-history/README.md
+++ b/spacesim/docs/1/feature/perf-history/README.md
@@ -1,0 +1,7 @@
+# Performance History
+
+Benchmark runs now save their results so we can track performance over time.
+After running `npm run test:perf` inside `spacesim`, a `latest.json` file
+is written to `spacesim/performance` and compared against `results.json`.
+If any benchmark runs slower than the previous result, a warning is printed.
+When no slowdown is detected, the baseline `results.json` is updated.

--- a/spacesim/package.json
+++ b/spacesim/package.json
@@ -7,6 +7,7 @@
     "build": "npm test && vite build",
     "preview": "vite preview",
     "test": "vitest run --coverage",
+    "pretest:e2e": "playwright install --with-deps",
     "test:e2e": "playwright test",
     "test:perf": "vitest bench --run --config vitest.performance.config.ts --outputJson performance/latest.json && node performance/compare.js"
   },

--- a/spacesim/package.json
+++ b/spacesim/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "test": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:perf": "vitest bench --run --config vitest.performance.config.ts"
+    "test:perf": "vitest bench --run --config vitest.performance.config.ts --outputJson performance/latest.json && node performance/compare.js"
   },
   "type": "module",
   "devDependencies": {

--- a/spacesim/performance/compare.js
+++ b/spacesim/performance/compare.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const dir = __dirname;
+const latestPath = path.join(dir, 'latest.json');
+const baselinePath = path.join(dir, 'results.json');
+
+function collectMeans(data){
+  const result = {};
+  if(!data.files) return result;
+  for(const file of data.files){
+    for(const group of file.groups||[]){
+      for(const bench of group.benchmarks||[]){
+        result[bench.name] = bench.mean;
+      }
+    }
+  }
+  return result;
+}
+
+if(!fs.existsSync(latestPath)){
+  console.error('latest.json not found');
+  process.exit(1);
+}
+const current = JSON.parse(fs.readFileSync(latestPath, 'utf8'));
+const curr = collectMeans(current);
+let baseline = null;
+if(fs.existsSync(baselinePath)){
+  baseline = collectMeans(JSON.parse(fs.readFileSync(baselinePath, 'utf8')));
+}
+let slower = false;
+if(baseline){
+  for(const name of Object.keys(curr)){
+    if(baseline[name] !== undefined && curr[name] > baseline[name]){
+      console.warn(`Warning: ${name} slower (mean ${curr[name].toFixed(2)} ms > ${baseline[name].toFixed(2)} ms)`);
+      slower = true;
+    }
+  }
+}
+if(!slower){
+  fs.copyFileSync(latestPath, baselinePath);
+}

--- a/spacesim/performance/compare.js
+++ b/spacesim/performance/compare.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-const dir = __dirname;
+const dir = path.dirname(fileURLToPath(import.meta.url));
 const latestPath = path.join(dir, 'latest.json');
 const baselinePath = path.join(dir, 'results.json');
 

--- a/test/perf-compare.test.js
+++ b/test/perf-compare.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const {execSync} = require('child_process');
+const assert = require('assert');
+
+function run(cmd){
+  return execSync(cmd, {encoding: 'utf8'});
+}
+
+const perfDir = path.join(__dirname, '..', 'spacesim', 'performance');
+const baseline = path.join(perfDir, 'results.json');
+const latest = path.join(perfDir, 'latest.json');
+
+function cleanup(){
+  if(fs.existsSync(baseline)) fs.unlinkSync(baseline);
+  if(fs.existsSync(latest)) fs.unlinkSync(latest);
+}
+
+try {
+  cleanup();
+  // slower case
+  fs.writeFileSync(baseline, JSON.stringify({files:[{groups:[{benchmarks:[{name:'bench', mean:10}]}]}]}));
+  fs.writeFileSync(latest, JSON.stringify({files:[{groups:[{benchmarks:[{name:'bench', mean:12}]}]}]}));
+  const outSlow = run('node spacesim/performance/compare.js');
+  assert(outSlow.includes('Warning'));
+
+  // faster case should update baseline
+  fs.writeFileSync(latest, JSON.stringify({files:[{groups:[{benchmarks:[{name:'bench', mean:9}]}]}]}));
+  const outFast = run('node spacesim/performance/compare.js');
+  assert(!outFast.includes('Warning'));
+  const data = JSON.parse(fs.readFileSync(baseline, 'utf8'));
+  const mean = data.files[0].groups[0].benchmarks[0].mean;
+  assert(mean === 9);
+  cleanup();
+  console.log('tests passed');
+} catch(err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/test/perf-compare.test.js
+++ b/test/perf-compare.test.js
@@ -4,7 +4,7 @@ const {execSync} = require('child_process');
 const assert = require('assert');
 
 function run(cmd){
-  return execSync(cmd, {encoding: 'utf8'});
+  return execSync(cmd + ' 2>&1', {encoding: 'utf8'});
 }
 
 const perfDir = path.join(__dirname, '..', 'spacesim', 'performance');


### PR DESCRIPTION
## Summary
- add perf history docs
- check latest performance benchmarks against previous run
- warn if benchmarks slowed down
- test perf comparison logic

## Testing
- `npm test` *(fails: browser.newContext: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_6881280670b083208d859c36bb5edeab