### PR TITLE
feat: apply retro styling

### DIFF
--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -32,3 +32,11 @@ The build script runs the test suite first and fails if unit test coverage drops
 `npm run test:perf` measures physics and renderer performance. The benchmarks are manual only and help track how many bodies we can simulate or draw at acceptable frame rates.
 
 See [../practices](../practices) for overall development guidelines.
+
+## Retro UI
+
+The application now features a built‑in retro theme styled after classic
+CRT interfaces. Panels and buttons glow in neon green and cyan to mimic an
+80s command deck. The file `ui-skeleton.html` remains as a standalone
+reference demonstrating the basic layout and can be opened directly in a
+browser.

--- a/spacesim/index.html
+++ b/spacesim/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spacesim</title>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/spacesim/src/components/BodyEditor.tsx
+++ b/spacesim/src/components/BodyEditor.tsx
@@ -55,7 +55,7 @@ export default function BodyEditor({ sim, body, onDeselect, frame }: Props) {
     onDeselect();
   };
   return (
-    <div style={{ position: 'absolute', top: '140px', left: '10px', background: '#2228', padding: '0.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <div className="panel" style={{ position: 'absolute', top: '140px', left: '10px', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
       <label>Name <input value={state.label} onInput={e => { setEdited(true); setState({ ...state, label: (e.target as HTMLInputElement).value }); }} /></label>
       <label>Mass <input type="number" step="0.1" value={state.mass} onInput={e => { setEdited(true); setState({ ...state, mass: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>
       <label>Radius <input type="number" step="1" value={state.radius} onInput={e => { setEdited(true); setState({ ...state, radius: parseFloat((e.target as HTMLInputElement).value) }); }} /></label>

--- a/spacesim/src/components/BodyLabels.tsx
+++ b/spacesim/src/components/BodyLabels.tsx
@@ -13,14 +13,11 @@ export default function BodyLabels({ sim }: Props) {
         return (
           <div
             key={b.data.label}
+            className="label"
             style={{
               position: 'absolute',
               left: `${screenX + b.data.radius + 2}px`,
               top: `${screenY - 10}px`,
-              pointerEvents: 'none',
-              color: '#fff',
-              fontSize: '12px',
-              whiteSpace: 'nowrap',
             }}
           >
             {b.data.label}

--- a/spacesim/src/components/BodyList.tsx
+++ b/spacesim/src/components/BodyList.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export default function BodyList({ sim, selected, onSelect }: Props) {
   return (
-    <ul style={{ position: 'absolute', right: '10px', bottom: '10px', listStyle: 'none', padding: '0.5rem', background: '#2228', color: '#eee' }}>
+    <ul className="panel" style={{ position: 'absolute', right: '10px', bottom: '10px', listStyle: 'none', padding: '0.5rem' }}>
       {sim.bodies.map((b) => (
         <li key={b.data.label} style={{ cursor: 'pointer', padding: '2px 4px', background: selected === b ? '#444' : 'transparent' }} onClick={() => onSelect(b)}>{b.data.label}</li>
       ))}

--- a/spacesim/src/components/BodySpawner.tsx
+++ b/spacesim/src/components/BodySpawner.tsx
@@ -14,7 +14,7 @@ export default function BodySpawner({ sim, disabled, params, onChange }: Props) 
   if (disabled) return null;
 
   return (
-    <div style={{ position: 'absolute', top: '60px', left: '10px', display: 'flex', gap: '0.5rem' }}>
+    <div className="panel" style={{ position: 'absolute', top: '60px', left: '10px', display: 'flex', gap: '0.5rem' }}>
       <label>Name <input value={label} onInput={e=>onChange({ ...params, label: (e.target as HTMLInputElement).value })} /></label>
       <label>Mass <input type="number" step="0.1" value={mass} onInput={e=>onChange({ ...params, mass: parseFloat((e.target as HTMLInputElement).value) })} /></label>
       <label>Radius <input type="number" step="1" value={radius} onInput={e=>onChange({ ...params, radius: parseFloat((e.target as HTMLInputElement).value) })} /></label>

--- a/spacesim/src/components/CanvasView.tsx
+++ b/spacesim/src/components/CanvasView.tsx
@@ -40,6 +40,7 @@ export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onM
   return (
     <canvas
       ref={ref}
+      className="sim-canvas"
       onClick={handleClick}
       onMouseDown={handleDown}
       onMouseMove={handleMove}

--- a/spacesim/src/components/DocsView.tsx
+++ b/spacesim/src/components/DocsView.tsx
@@ -43,8 +43,8 @@ export default function DocsView() {
   const load = (file: string) => loadFile(major, file);
 
   return (
-    <div style={{position:'absolute', inset:0, display:'flex', color:'#fff'}}>
-      <div style={{width:'220px', padding:'1rem', boxSizing:'border-box', overflowY:'auto', marginTop:'60px'}}>
+    <div className="docs-container" style={{position:'absolute', inset:0, display:'flex'}}>
+      <div className="panel" style={{width:'220px', padding:'1rem', boxSizing:'border-box', overflowY:'auto', marginTop:'60px'}}>
         <div style={{marginBottom:'1rem'}}>
           <label>
             Version:
@@ -59,7 +59,7 @@ export default function DocsView() {
           ))}
         </ul>
       </div>
-      <div style={{flex:1, padding:'1rem', overflowY:'auto', marginTop:'60px'}}>
+      <div className="docs-content" style={{flex:1, padding:'1rem', overflowY:'auto', marginTop:'60px'}}>
         <div dangerouslySetInnerHTML={{__html: content}} />
       </div>
     </div>

--- a/spacesim/src/components/Root.tsx
+++ b/spacesim/src/components/Root.tsx
@@ -7,8 +7,8 @@ export default function Root() {
   const [tab, setTab] = useState<'sandbox' | 'scenario' | 'docs'>('sandbox');
 
   return (
-    <div style={{ position:'relative', width:'100vw', height:'100vh' }}>
-      <div style={{ position:'absolute', top:'10px', left:'10px', display:'flex', gap:'0.5rem', zIndex:1 }}>
+    <div className="app-root">
+      <div className="hud-buttons">
         <button onClick={() => setTab('sandbox')}>Sandbox</button>
         <button onClick={() => setTab('scenario')}>Scenario</button>
         <button onClick={() => setTab('docs')}>Docs</button>

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -78,9 +78,9 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
   const resetSpeed = () => { sim.resetSpeed(); setSpeed(sim.speed); };
 
   return (
-    <div style={{ position:'relative', width:'100%', height:'100%' }}>
+    <div className="sim-container" style={{ position:'relative', width:'100%', height:'100%' }}>
       <CanvasView sim={sim} onMouseDown={down} onMouseMove={move} onMouseUp={up} />
-      <div style={{ position:'absolute', top:'10px', right:'10px', display:'flex', flexDirection:'column', gap:'0.25rem' }}>
+      <div className="panel" style={{ position:'absolute', top:'10px', right:'10px', display:'flex', flexDirection:'column', gap:'0.25rem' }}>
         <div style={{ display:'flex', gap:'0.25rem' }}>
           <button onClick={toggleRun}>{running ? 'Pause' : 'Start'}</button>
           <button onClick={reset}>Reset</button>

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -1,2 +1,61 @@
-body { margin: 0; background: #111; color: #eee; font-family: sans-serif; }
-canvas { display: block; width: 100vw; height: 100vh; background: #000; }
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+
+body {
+  margin: 0;
+  background: #000;
+  color: #0f0;
+  font-family: 'VT323', monospace;
+  text-shadow: 0 0 2px #0f0;
+}
+
+.app-root {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+}
+
+.hud-buttons {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: flex;
+  gap: 0.5rem;
+  z-index: 1;
+}
+
+button {
+  background: #111;
+  color: #0f0;
+  border: 1px solid #0f0;
+  padding: 0.25em 0.5em;
+  font-family: inherit;
+  cursor: pointer;
+}
+button:hover {
+  background: #0f0;
+  color: #000;
+}
+
+.panel {
+  background: #111;
+  border: 1px solid #0ff;
+  padding: 0.5em;
+  color: #0f0;
+}
+
+canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  background: #000;
+  border: 1px solid #0f0;
+  box-shadow: 0 0 10px #0f0;
+}
+
+.label {
+  pointer-events: none;
+  color: #0f0;
+  font-size: 12px;
+  white-space: nowrap;
+  text-shadow: 0 0 4px #0f0;
+}

--- a/spacesim/ui-skeleton.html
+++ b/spacesim/ui-skeleton.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retro UI Skeleton</title>
+  <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      background: #000;
+      color: #0f0;
+      font-family: 'VT323', monospace;
+      text-shadow: 0 0 3px #0f0;
+    }
+    .hud-bar, .status-footer {
+      background: #111;
+      padding: 0.5em;
+      text-align: center;
+      border-bottom: 2px solid #0ff;
+    }
+    .status-footer {
+      border-top: 2px solid #0ff;
+      border-bottom: none;
+    }
+    .main-container {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+    }
+    .terminal-panel, .control-deck {
+      width: 20%;
+      background: #111;
+      border: 1px solid #0ff;
+      padding: 1em;
+      overflow-y: auto;
+    }
+    .canvas-wrapper {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background: radial-gradient(circle, #000 60%, #111);
+      position: relative;
+    }
+    #sim-canvas {
+      width: 100%;
+      height: 100%;
+      border: 1px solid #0f0;
+      box-shadow: 0 0 10px #0f0;
+    }
+    /* optional CRT scanline effect */
+    .canvas-wrapper::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      background: repeating-linear-gradient(
+        0deg,
+        rgba(0,0,0,0) 0px,
+        rgba(0,0,0,0) 2px,
+        rgba(0,0,0,0.05) 3px,
+        rgba(0,0,0,0.05) 4px
+      );
+    }
+  </style>
+</head>
+<body>
+  <header class="hud-bar">Top HUD bar</header>
+  <main class="main-container">
+    <aside class="terminal-panel">Terminal/logs or mission script</aside>
+    <section class="canvas-wrapper">
+      <canvas id="sim-canvas"></canvas>
+    </section>
+    <aside class="control-deck">Mockup of ship/system controls</aside>
+  </main>
+  <footer class="status-footer">Status bar / diagnostics</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add VT323 font to Spacesim index page
- design neon theme in `style.css`
- attach retro classes to UI components
- update docs about the new built-in theme

## Testing
- `npm --prefix spacesim test`
- `npm test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68812d5c0cdc8320821fed79ced531d5