### PR TITLE
Fix spawn velocity scaling

### DIFF
--- a/feature/drag-spawn/README.md
+++ b/feature/drag-spawn/README.md
@@ -1,9 +1,10 @@
 # Drag to Spawn Bodies
 
-Dragging on the canvas spawns a new body. The drag distance and direction determine its initial velocity using `throwVelocity`.
+-Dragging on the canvas spawns a new body. The drag distance and direction determine its initial velocity using `throwVelocity`.
 
-- Very short drags still create a body but with near-zero velocity.
+- Very short drags (under ~3 screen pixels) create a stationary body.
 - A green line shows the drag vector while held.
+- Drag distance is measured in screen space so the push feels consistent at any zoom level.
 - The body is created on mouse release using the parameters from the spawner panel and a unique label.
 - Clicking an existing body selects it instead of starting a drag.
 - Implemented in `spacesim`.

--- a/spacesim/docs/1/feature/drag-spawn/README.md
+++ b/spacesim/docs/1/feature/drag-spawn/README.md
@@ -1,9 +1,10 @@
 # Drag to Spawn Bodies
 
-Dragging on the canvas spawns a new body. The drag distance and direction determine its initial velocity using `throwVelocity`.
+-Dragging on the canvas spawns a new body. The drag distance and direction determine its initial velocity using `throwVelocity`.
 
-- Very short drags still create a body but with near-zero velocity.
+- Very short drags (under ~3 screen pixels) create a stationary body.
 - A green line shows the drag vector while held.
+- Drag distance is measured in screen space so the push feels consistent at any zoom level.
 - The body is created on mouse release using the parameters from the spawner panel and a unique label.
 - Clicking an existing body selects it instead of starting a drag.
 - Implemented in `spacesim`.

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -60,7 +60,7 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
 
   const up = (pos: Vec2) => {
     if (!dragStart) return;
-    const velocity = throwVelocity(dragStart, pos);
+    const velocity = throwVelocity(dragStart, pos, sim.view.zoom);
     const label = uniqueName(spawnParams.label, sim.bodies.map(b=>b.data.label));
     sim.addBody(dragStart, velocity, { ...spawnParams, label });
     setDragStart(null);

--- a/spacesim/src/renderers/threeRenderer.ts
+++ b/spacesim/src/renderers/threeRenderer.ts
@@ -143,7 +143,7 @@ export class ThreeRenderer {
       }
       return;
     }
-    const vel = throwVelocity(line.start, line.end);
+    const vel = throwVelocity(line.start, line.end, this.camera.zoom);
     const type = predictOrbitType(line.start, vel, cPos, central.data.mass, central.data.radius, G);
     const color = type === 'escape' ? 'blue' : type === 'crash' ? 'red' : 'green';
     const geom = new BufferGeometry().setFromPoints([

--- a/spacesim/src/throwVelocity.test.ts
+++ b/spacesim/src/throwVelocity.test.ts
@@ -4,13 +4,19 @@ import { throwVelocity } from './utils';
 
 describe('throwVelocity', () => {
   it('returns zero vector for small drag', () => {
-    const v = throwVelocity(Vec2(0,0), Vec2(2,2));
+    const v = throwVelocity(Vec2(0,0), Vec2(2,2), 1);
     expect(v.x).toBe(0);
     expect(v.y).toBe(0);
   });
 
   it('returns scaled velocity for drag', () => {
-    const v = throwVelocity(Vec2(0,0), Vec2(20,0));
+    const v = throwVelocity(Vec2(0,0), Vec2(20,0), 1);
     expect(v.x).toBeGreaterThan(0);
+  });
+
+  it('uses screen distance for weighting', () => {
+    const v1 = throwVelocity(Vec2(0,0), Vec2(100,0), 1);
+    const v2 = throwVelocity(Vec2(0,0), Vec2(50,0), 2);
+    expect(v1.x).toBeCloseTo(v2.x);
   });
 });

--- a/spacesim/src/utils.ts
+++ b/spacesim/src/utils.ts
@@ -10,11 +10,13 @@ export function uniqueName(base: string, existing: string[]): string {
   return candidate;
 }
 
-export function throwVelocity(start: Vec2, end: Vec2) {
+export function throwVelocity(start: Vec2, end: Vec2, zoom = 1) {
   const drag = Vec2.sub(end, start);
-  const speed = drag.length();
-  if (speed < 5) return Vec2();
-  return drag.mul(0.01 * speed / (speed + 50));
+  const dist = drag.length();
+  const px = dist * zoom;
+  if (px <= 3) return Vec2();
+  const scale = 0.01 * px * px / (px + 50) / (dist || 1);
+  return drag.mul(scale);
 }
 
 export type OrbitType = 'crash' | 'stable' | 'escape';


### PR DESCRIPTION
## Summary
- compute spawn velocity in screen space so zoom doesn't affect drag
- update tests for new throwVelocity behavior
- document drag distance tolerance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68813d6118548320aa2ed61ebc02fd8a