### PR TITLE
Add massless-body test

### DIFF
--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -102,4 +102,14 @@ describe('Sandbox gravity', () => {
     expect(vel.x).toBeCloseTo(3);
     expect(vel.y).toBeCloseTo(4);
   });
+
+  it('maintains zero velocity when masses are zero', () => {
+    const sb = new PhysicsEngine();
+    sb.addBody(Vec2(0, 0), Vec2(), { mass: 0, radius: 1, color: 'red', label: 'a' });
+    sb.addBody(Vec2(5, 0), Vec2(), { mass: 0, radius: 1, color: 'blue', label: 'b' });
+    sb.step(1 / 60);
+    const [a, b] = sb.bodies;
+    expect(a.body.getLinearVelocity().length()).toBe(0);
+    expect(b.body.getLinearVelocity().length()).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- verify bodies don't move when masses are zero

## Testing
- `npm test` *(fails: edit body label e2e test fails)*

------
https://chatgpt.com/codex/tasks/task_e_68814340a12883208817660973bf75b0