### PR TITLE
Fix gravity force scaling with radius

### DIFF
--- a/bugfix/gravity-calculation/README.md
+++ b/bugfix/gravity-calculation/README.md
@@ -1,0 +1,14 @@
+# Gravity force mismatch
+
+## Issue
+Bodies with the same mass but different radii accelerated at noticeably different rates when approaching each other. Gravity calculations relied on Planck.js density, so the actual mass used by the physics engine scaled with body area. Large bodies therefore experienced much smaller acceleration.
+
+## Root cause
+`addBody` and `updateBody` set the fixture density equal to the mass value. Planck multiplies density by shape area to compute mass, so the simulation mass increased with radius. The gravitational force used the raw `data.mass` value which no longer matched the body's actual mass in the world, leading to inconsistent motion.
+
+## Fix
+Density is now derived from `mass / (πr²)` so Planck's computed mass matches the logical mass. `applyGravity` was rewritten using a clearer formula and tests verify that equal masses accelerate equally regardless of radius.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/src/components/root.test.tsx
+++ b/spacesim/src/components/root.test.tsx
@@ -6,6 +6,7 @@ import * as hooks from 'preact/hooks';
 vi.mock('../simulation', () => ({
   Simulation: class {
     speed = 1;
+    time = 0;
     bodies = [];
     view = { zoom: 1, center: { x: 0, y: 0 } };
     onRender() { return () => {}; }

--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -26,7 +26,7 @@ describe('Sandbox gravity', () => {
     const start = sb.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: '' });
     if (start) sb.updateBody(start, { mass: 2 });
     const fixture = start?.body.getFixtureList();
-    expect(fixture?.getDensity()).toBe(2);
+    expect(fixture?.getDensity()).toBeCloseTo(2 / Math.PI, 6);
   });
 
   it('updates body radius', () => {
@@ -101,5 +101,15 @@ describe('Sandbox gravity', () => {
     const vel = body.body.getLinearVelocity();
     expect(vel.x).toBeCloseTo(3);
     expect(vel.y).toBeCloseTo(4);
+  });
+
+  it('applies equal acceleration for equal masses regardless of radius', () => {
+    const sb = new PhysicsEngine();
+    const a = sb.addBody(Vec2(0, 0), Vec2(), { mass: 2, radius: 1, color: 'red', label: 'a' });
+    const b = sb.addBody(Vec2(10, 0), Vec2(), { mass: 2, radius: 5, color: 'blue', label: 'b' });
+    sb.step(1);
+    const va = a.body.getLinearVelocity().x;
+    const vb = b.body.getLinearVelocity().x;
+    expect(Math.abs(va)).toBeCloseTo(Math.abs(vb), 5);
   });
 });


### PR DESCRIPTION
## Summary
- prevent inaccurate mass by scaling Planck fixture density with body radius
- update gravity formula for clarity
- adjust physics tests and simulation test stub
- document fix under `bugfix/gravity-calculation`

## Testing
- `npm --prefix spacesim test` *(fails: Coverage for lines (0%) does not meet global threshold (60%) when running only docsView tests)*


------
https://chatgpt.com/codex/tasks/task_e_6881469d94d88320a0bf33c0a4c5743f