### PR TITLE
fix: stable physics time step

### DIFF
--- a/bugfix/accumulator-loop/README.md
+++ b/bugfix/accumulator-loop/README.md
@@ -1,0 +1,14 @@
+# Physics accumulator loop
+
+## Issue
+Long frames caused the simulation to advance with a very large `dt`. Bodies would shoot off course whenever the browser was paused or lost focus.
+
+## Root cause
+`Simulation.step` passed the raw time delta from `GameLoop` directly to the physics engine. When that value exceeded a few milliseconds the integration became unstable.
+
+## Fix
+`Simulation` now accumulates the delta and steps the physics engine in fixed `1/60s` increments. Each frame contributes at most `0.1s` to the accumulator to avoid the spiral of death. Tests cover the new behaviour.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -109,8 +109,10 @@ describe('Sandbox gravity', () => {
     const b = sb.addBody(Vec2(10, 0), Vec2(), { mass: 2, radius: 5, color: 'blue', label: 'b' });
     sb.step(1);
     const va = a.body.getLinearVelocity().x;
-    const vb = b.body.getLinearVelocity().x;
-    expect(Math.abs(va)).toBeCloseTo(Math.abs(vb), 5);
+  const vb = b.body.getLinearVelocity().x;
+  expect(Math.abs(va)).toBeCloseTo(Math.abs(vb), 5);
+  });
+
   it('maintains zero velocity when masses are zero', () => {
     const sb = new PhysicsEngine();
     sb.addBody(Vec2(0, 0), Vec2(), { mass: 0, radius: 1, color: 'red', label: 'a' });

--- a/spacesim/src/simulation.test.ts
+++ b/spacesim/src/simulation.test.ts
@@ -23,17 +23,17 @@ describe('Simulation scenarios', () => {
     const sim = new Simulation();
     const stepSpy = vi.spyOn(sim['engine'], 'step');
     sim.speedUp();
-    sim['step'](0.5 as any);
-    const arg = stepSpy.mock.calls[0][0];
-    expect(arg).toBeCloseTo(1);
+    sim['step'](0.05 as any);
+    const total = stepSpy.mock.calls.reduce((s, c) => s + c[0], 0);
+    expect(total).toBeCloseTo(0.1);
   });
 
   it('tracks elapsed time', () => {
     const sim = new Simulation();
-    sim['step'](0.25 as any);
-    expect(sim.time).toBeCloseTo(0.25);
+    sim['step'](0.05 as any);
+    expect(sim.time).toBeCloseTo(0.05);
     sim.speedUp();
-    sim['step'](0.25 as any);
-    expect(sim.time).toBeCloseTo(0.75);
+    sim['step'](0.05 as any);
+    expect(sim.time).toBeCloseTo(0.15);
   });
 });

--- a/spacesim/src/simulation.ts
+++ b/spacesim/src/simulation.ts
@@ -33,6 +33,9 @@ export class Simulation {
 
   private overlay?: { start: Vec2; end: Vec2 } | null;
 
+  private accumulator = 0;
+  private readonly fixedDt = 1 / 60;
+
   private speedIndex = 0; // 0 -> x1
 
   get speed() { return 2 ** this.speedIndex; }
@@ -108,16 +111,20 @@ export class Simulation {
 
   private step(dt: number) {
     const scaled = dt * this.speed;
-    this._time += scaled;
-    if (this.scenario) {
-      while (this.scenario.length && this.scenario[0].time <= this._time) {
-        const ev = this.scenario.shift()!;
-        if (ev.action === 'addBody') {
-          this.engine.addBody(ev.position, ev.velocity, ev.data);
+    this.accumulator += Math.min(scaled, 0.1);
+    while (this.accumulator >= this.fixedDt) {
+      this._time += this.fixedDt;
+      if (this.scenario) {
+        while (this.scenario.length && this.scenario[0].time <= this._time) {
+          const ev = this.scenario.shift()!;
+          if (ev.action === 'addBody') {
+            this.engine.addBody(ev.position, ev.velocity, ev.data);
+          }
         }
       }
+      this.engine.step(this.fixedDt);
+      this.accumulator -= this.fixedDt;
     }
-    this.engine.step(scaled);
     this.bus.emit('render', {
       bodies: this.engine.bodies,
       throwLine: this.overlay || undefined,


### PR DESCRIPTION
## Summary
- implement accumulator loop in Simulation.step
- adjust tests for new time stepping
- document bug in bugfix/accumulator-loop

## Testing
- `npm --prefix spacesim test`
- ❌ `npm test` *(fails: playwright install canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68815015f218832096b1ea822cd0d2a9