### PR TITLE
Add keyboard and wheel controls

### DIFF
--- a/feature/zoom-pan/README.md
+++ b/feature/zoom-pan/README.md
@@ -5,7 +5,7 @@ The simulation view can be zoomed, panned and centered on a body.
 - `Simulation` tracks a `view` with `center` and `zoom` values and exposes helper methods.
 - `ThreeRenderer` applies the transform when drawing the scene.
 - `CanvasView` converts mouse coordinates using `screenToWorld`.
-- Toolbar controls allow zooming with +/-, panning with arrows and centering on the selected body.
+- Toolbar controls allow zooming with +/-, panning with arrows and centering on the selected body. Users can also pan with the keyboard arrow keys and zoom using the mouse wheel for smoother interaction.
 - Documented in this feature and covered by unit tests in `src/view.test.ts`.
 
 ## Tests

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -82,6 +82,26 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
   const slower = () => { sim.slowDown(); setSpeed(sim.speed); };
   const resetSpeed = () => { sim.resetSpeed(); setSpeed(sim.speed); };
 
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowUp') { e.preventDefault(); pan(0, -20); }
+      else if (e.key === 'ArrowDown') { e.preventDefault(); pan(0, 20); }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); pan(-20, 0); }
+      else if (e.key === 'ArrowRight') { e.preventDefault(); pan(20, 0); }
+    };
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const factor = Math.pow(1.1, -e.deltaY / 100);
+      sim.zoom(factor);
+    };
+    window.addEventListener('keydown', handleKey, { passive: false });
+    window.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      window.removeEventListener('wheel', handleWheel);
+    };
+  }, [sim]);
+
   return (
     <div className="sim-container" style={{ position:'relative', width:'100%', height:'100%' }}>
       <CanvasView sim={sim} onMouseDown={down} onMouseMove={move} onMouseUp={up} />

--- a/spacesim/src/components/keyboardZoom.test.tsx
+++ b/spacesim/src/components/keyboardZoom.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'preact';
+import SimulationComponent from './Simulation';
+
+const baseSim = {
+  onRender: () => () => {},
+  start: () => {},
+  stop: () => {},
+  loadScenario: () => {},
+  speed: 1,
+  time: 0,
+  bodies: [],
+  view: { zoom: 1, center: { x: 0, y: 0 } },
+  findBody: () => null,
+  setOverlay: () => {},
+  setCanvas: () => {},
+  addBody: () => ({ body: {}, data: {} }),
+  centerOn: () => {},
+  reset: () => {},
+  resetView: () => {},
+  speedUp: () => {},
+  slowDown: () => {},
+  resetSpeed: () => {},
+} as any;
+
+describe('keyboard and wheel controls', () => {
+  it('pans view with arrow keys', async () => {
+    const pan = vi.fn();
+    const sim = { ...baseSim, pan, zoom: () => {} } as any;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<SimulationComponent sim={sim} />, container);
+    await new Promise(r => setTimeout(r, 20));
+    window.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(pan).toHaveBeenCalled();
+  });
+
+  it('zooms with mouse wheel', async () => {
+    const zoom = vi.fn();
+    const sim = { ...baseSim, pan: () => {}, zoom } as any;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<SimulationComponent sim={sim} />, container);
+    await new Promise(r => setTimeout(r, 20));
+    window.dispatchEvent(new window.WheelEvent('wheel', { deltaY: -100, bubbles: true }));
+    expect(zoom).toHaveBeenCalled();
+  });
+});

--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -111,6 +111,8 @@ describe('Sandbox gravity', () => {
     const va = a.body.getLinearVelocity().x;
     const vb = b.body.getLinearVelocity().x;
     expect(Math.abs(va)).toBeCloseTo(Math.abs(vb), 5);
+  });
+
   it('maintains zero velocity when masses are zero', () => {
     const sb = new PhysicsEngine();
     sb.addBody(Vec2(0, 0), Vec2(), { mass: 0, radius: 1, color: 'red', label: 'a' });


### PR DESCRIPTION
## Summary
- fix incomplete physics test
- allow panning and zooming via keyboard arrows and mouse wheel
- document new shortcuts
- test the new controls

## Testing
- `npm --prefix spacesim test`
- `npm --prefix spacesim run test:e2e`
- `npm --prefix spacesim run test:perf` *(fails: SyntaxError in compare.js)*
- `npm test` *(fails: SyntaxError in compare.js)*

------
https://chatgpt.com/codex/tasks/task_e_6881523dad308320a2694c7a0f516763