### PR TITLE
Add simple Rapier2D engine module

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,3 @@
+# Engine
+
+Demonstrates a minimal Rapier2D setup with manual gravity. The module exports a shared `world`, a `createBody` helper and `stepPhysics` to advance the simulation.

--- a/engine/physics.ts
+++ b/engine/physics.ts
@@ -1,0 +1,40 @@
+import * as RAPIER from '@dimforge/rapier2d';
+
+const gravity = { x: 0, y: 0 };
+export const world = new RAPIER.World(gravity);
+
+const G = 6.67430e-11;
+
+export function createBody(x: number, y: number, vx: number, vy: number, mass: number): RAPIER.RigidBody {
+  const desc = RAPIER.RigidBodyDesc.dynamic()
+    .setTranslation(x, y)
+    .setLinvel(vx, vy)
+    .setAdditionalMass(mass);
+  return world.createRigidBody(desc);
+}
+
+function applyOrbitalGravity() {
+  const bodies = world.bodies();
+  for (let i = 0; i < bodies.length; i++) {
+    for (let j = i + 1; j < bodies.length; j++) {
+      const a = bodies[i];
+      const b = bodies[j];
+      const pa = a.translation();
+      const pb = b.translation();
+      const dx = pb.x - pa.x;
+      const dy = pb.y - pa.y;
+      const distSq = dx * dx + dy * dy;
+      const dist = Math.sqrt(distSq) + 1e-6;
+      const forceMag = G * a.mass() * b.mass() / distSq;
+      const fx = forceMag * dx / dist;
+      const fy = forceMag * dy / dist;
+      a.applyForce({ x: fx, y: fy }, true);
+      b.applyForce({ x: -fx, y: -fy }, true);
+    }
+  }
+}
+
+export function stepPhysics(_dt: number) {
+  applyOrbitalGravity();
+  world.step();
+}

--- a/engine/spaceTransform.ts
+++ b/engine/spaceTransform.ts
@@ -1,0 +1,5 @@
+export const METERS_PER_PIXEL = 1;
+
+export function toRender({ x, y }: { x: number; y: number }, canvasHeight: number) {
+  return { x: x / METERS_PER_PIXEL, y: canvasHeight - y / METERS_PER_PIXEL };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "codex2",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "@dimforge/rapier2d": "^0.18.0-beta.0"
+      },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1"
@@ -294,6 +297,12 @@
       "engines": {
         "node": ">=v18"
       }
+    },
+    "node_modules/@dimforge/rapier2d": {
+      "version": "0.18.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d/-/rapier2d-0.18.0-beta.0.tgz",
+      "integrity": "sha512-J8VbUGifGwU9FoqTCB+s+ruNBhy/DUmNS0JMlbp82j4vLb8/OrL2ndd9XFro05X6zlawY44+kGV24T41ExlRLQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1"
+  },
+  "dependencies": {
+    "@dimforge/rapier2d": "^0.18.0-beta.0"
   }
 }

--- a/test/engine-physics.test.js
+++ b/test/engine-physics.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+(async () => {
+  const mod = await import('../engine/physics.ts');
+  const { createBody, stepPhysics } = mod;
+  const a = createBody(0, 0, 0, 0, 1);
+  const b = createBody(1, 0, 0, 0, 1);
+  stepPhysics(1 / 60);
+  const vxA = a.linvel().x;
+  const vxB = b.linvel().x;
+  assert(vxA > 0 && vxB < 0);
+  console.log('tests passed');
+})();


### PR DESCRIPTION
## Summary
- create new `engine` module as a minimal Rapier2D sandbox
- expose helpers to create bodies and step physics
- provide render-space transform util
- add a basic Node test
- install Rapier2D dependency

## Testing
- `npm test` *(fails: ReferenceError exports is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688155f92c3c8320b14b8afc8de2255d