### PR TITLE
Add fast guidance summary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Guidance for AI Coding Agents
 
+## Quick Reference
+The condensed rules are stored in `FAST_GUIDANCE.md`. Use that file when asked to
+"be brief". It summarizes the workflow so you can recall it quickly. Review the
+full documentation if anything is unclear or when the docs change.
+
 Welcome, coding agent! Follow these instructions whenever you work in this repository:
 
 1. **Read Documentation First**

--- a/FAST_GUIDANCE.md
+++ b/FAST_GUIDANCE.md
@@ -1,0 +1,21 @@
+# Fast Guidance
+
+This file distills the core practices for quick reference.
+
+## Workflow Essentials
+- Read the current folder's `README.md` and `AGENTS.md` along with their parents.
+- Document planned work before coding.
+- Write tests first and aim for at least 60% coverage.
+- Run `npm install` and then `npm test` to execute all suites.
+- Use Conventional Commit style: `feat:`, `fix:`, or `chore:` and reference feature/bugfix folders.
+- Update documentation and tests whenever behavior changes.
+
+## UI Guidelines
+- Keep interfaces simple and consistent.
+- Provide feedback and ensure accessibility.
+
+## Spacesim Notes
+- Simulation uses Planck.js and has unit tests under `src/`.
+- Run `npm install` before building or testing.
+
+Use this summary when asked to "be brief". Consult the full docs if any detail is unclear.


### PR DESCRIPTION
## Summary
- create **FAST_GUIDANCE.md** as a condensed reference
- point main `AGENTS.md` at the new quick-reference file

## Testing
- `npm install`
- `npm --prefix spacesim install`
- `npm test` *(fails: ReferenceError: exports is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6881587c3630832085cdd898ed04b0f8