### PR TITLE
Refactor game loop for delta timing

### DIFF
--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -6,7 +6,7 @@ Bodies are spawned by dragging on the canvas while the spawner panel is visible.
 
 Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
 
-The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks using RxJS intervals and the `PhysicsEngine` handles Planck.js dynamics. A single `ThreeRenderer` listens for render events and draws bodies, orbit trails and the drag line using Three.js.
+The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks once per animation frame using RxJS and passes the elapsed time to the simulation. `PhysicsEngine` handles Planck.js dynamics. A single `ThreeRenderer` listens for render events and draws bodies, orbit trails and the drag line using Three.js.
 
 Bodies also render dotted orbit trails based on their current trajectory. The trail uses the body's color unless it is escaping (blue) or on a collision course (red).
 

--- a/spacesim/docs/1/spacesim/README.md
+++ b/spacesim/docs/1/spacesim/README.md
@@ -6,7 +6,7 @@ Bodies are spawned by dragging on the canvas while the spawner panel is visible.
 
 Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
 
-The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks using RxJS intervals and the `PhysicsEngine` handles Planck.js dynamics. A single `ThreeRenderer` listens for render events and draws bodies, orbit trails and the drag line using Three.js.
+The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks once per animation frame using RxJS and passes the elapsed time to the simulation. `PhysicsEngine` handles Planck.js dynamics. A single `ThreeRenderer` listens for render events and draws bodies, orbit trails and the drag line using Three.js.
 
 Bodies also render dotted orbit trails based on their current trajectory. The trail uses the body's color unless it is escaping (blue) or on a collision course (red).
 

--- a/spacesim/src/core/gameLoop.test.ts
+++ b/spacesim/src/core/gameLoop.test.ts
@@ -8,30 +8,27 @@ describe('GameLoop', () => {
     const bus = createEventBus<{ tick: number }>();
     const handler = vi.fn();
     bus.on('tick', handler);
-    const loop = new GameLoop(bus, 0.1);
+    const loop = new GameLoop(bus);
     loop.start();
-    vi.advanceTimersByTime(300); // 3 steps
+    vi.advanceTimersByTime(48); // ~3 frames
     loop.stop();
     expect(handler).toHaveBeenCalledTimes(3);
     vi.useRealTimers();
   });
 
-  it('accumulates time and emits fixed steps', async () => {
-    vi.useRealTimers();
+  it('passes frame delta to handlers', () => {
+    vi.useFakeTimers();
     const bus = createEventBus<{ tick: number }>();
     const dts: number[] = [];
-    const loop = new GameLoop(bus, 0.05);
+    const loop = new GameLoop(bus);
     bus.on('tick', (dt) => {
       dts.push(dt);
-      if (dts.length >= 4) loop.stop();
+      if (dts.length >= 3) loop.stop();
     });
     loop.start();
-    await new Promise((r) => setTimeout(r, 70));
-    const stop = Date.now();
-    while (Date.now() - stop < 200) {}
-    await new Promise((r) => setTimeout(r, 70));
-    expect(dts[0]).toBeCloseTo(0.05, 2);
-    for (const dt of dts) expect(dt).toBeCloseTo(0.05, 2);
-    expect(dts.length).toBeGreaterThan(2);
+    vi.advanceTimersByTime(48);
+    expect(dts.length).toBe(3);
+    for (const dt of dts) expect(dt).toBeCloseTo(0.016, 2);
+    vi.useRealTimers();
   });
 });

--- a/spacesim/src/core/gameLoop.ts
+++ b/spacesim/src/core/gameLoop.ts
@@ -1,30 +1,25 @@
-import { interval, Subscription, animationFrameScheduler } from 'rxjs';
+import { animationFrames, Subscription } from 'rxjs';
 import type { EventBus } from './eventBus';
 
 export class GameLoop<Events extends Record<string, any>> {
   private sub?: Subscription;
   private last = 0;
-  private accumulator = 0;
 
-  constructor(private bus: EventBus<Events>, private step = 1 / 60) {}
+  constructor(private bus: EventBus<Events>) {}
 
   start(): void {
     if (this.sub) return;
-    this.last = Date.now();
-    this.sub = interval(this.step * 1000, animationFrameScheduler).subscribe(() => {
-      const now = Date.now();
-      this.accumulator += (now - this.last) / 1000;
-      this.last = now;
-      while (this.accumulator >= this.step) {
-        this.bus.emit('tick' as keyof Events, this.step);
-        this.accumulator -= this.step;
-      }
+    this.sub = animationFrames().subscribe(({ timestamp }) => {
+      if (!this.last) this.last = timestamp;
+      const dt = (timestamp - this.last) / 1000;
+      this.last = timestamp;
+      this.bus.emit('tick' as keyof Events, dt);
     });
   }
 
   stop(): void {
     this.sub?.unsubscribe();
     this.sub = undefined;
-    this.accumulator = 0;
+    this.last = 0;
   }
 }

--- a/spacesim/src/physics/engine.ts
+++ b/spacesim/src/physics/engine.ts
@@ -1,4 +1,7 @@
-import * as RAPIER from '@dimforge/rapier2d-compat';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const RAPIER: typeof import('@dimforge/rapier2d-compat') = require('@dimforge/rapier2d-compat');
 import Vec2, { Vector } from '../vec2';
 
 export interface BodyData {

--- a/spacesim/src/simulation.ts
+++ b/spacesim/src/simulation.ts
@@ -23,7 +23,7 @@ interface Events {
 export class Simulation {
   private engine = new PhysicsEngine();
   private bus: EventBus<Events> = createEventBus<Events>();
-  private loop = new GameLoop(this.bus, 1 / 25);
+  private loop = new GameLoop(this.bus);
   private renderer?: ThreeRenderer;
   private _time = 0;
   get time() { return this._time; }


### PR DESCRIPTION
## Summary
- refactor GameLoop to use animation frame timing
- update physics engine import
- adjust simulation to new GameLoop API
- document new timing approach
- update tests for the new API

## Testing
- `npm test` *(fails: exports is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68815cf266648320972ca58429f90eb4