### PR TITLE
Fix physics step scaling

### DIFF
--- a/engine/physics.ts
+++ b/engine/physics.ts
@@ -34,7 +34,7 @@ function applyOrbitalGravity() {
   }
 }
 
-export function stepPhysics(_dt: number) {
+export function stepPhysics(dt: number) {
   applyOrbitalGravity();
-  world.step();
+  world.step(dt);
 }

--- a/spacesim/src/core/gameLoop.ts
+++ b/spacesim/src/core/gameLoop.ts
@@ -10,7 +10,7 @@ export class GameLoop<Events extends Record<string, any>> {
   start(): void {
     if (this.sub) return;
     this.sub = animationFrames().subscribe(({ timestamp }) => {
-      if (!this.last) this.last = timestamp;
+      if (!this.last) this.last = timestamp - 1000 / 60;
       const dt = (timestamp - this.last) / 1000;
       this.last = timestamp;
       this.bus.emit('tick' as keyof Events, dt);


### PR DESCRIPTION
## Summary
- use delta when stepping Rapier world
- initialize game loop timer to avoid zero delta frame

## Testing
- `npm test` *(fails: page.goto: Test ended)*

------
https://chatgpt.com/codex/tasks/task_e_688164c15098832096db56a92f517f8b