### PR TITLE
Add ship cockpit view

### DIFF
--- a/feature/shipview/README.md
+++ b/feature/shipview/README.md
@@ -1,0 +1,7 @@
+# Shipview Cockpit
+
+- Added a new **Shipview** tab to the UI.
+- Presents a basic cockpit layout with three angled panels and a console.
+- The centre window is reserved for space imagery or the simulation.
+
+Tests: `spacesim/src/components/shipView.test.tsx` and `spacesim/src/components/root.test.tsx`.

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -6,6 +6,10 @@ Bodies are spawned by dragging on the canvas while the spawner panel is visible.
 
 Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
 
+A new **Shipview** tab displays a basic cockpit layout. Three angled panels and
+a bottom console create a simple 3D illusion. The centre "window" will later
+host the simulation or space imagery.
+
 The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks once per animation frame using RxJS and passes the elapsed time to the simulation. `PhysicsEngine` handles Planck.js dynamics. A single `ThreeRenderer` listens for render events and draws bodies, orbit trails and the drag line using Three.js.
 
 Bodies also render dotted orbit trails based on their current trajectory. The trail uses the body's color unless it is escaping (blue) or on a collision course (red).

--- a/spacesim/src/components/Root.tsx
+++ b/spacesim/src/components/Root.tsx
@@ -2,9 +2,10 @@ import { useState } from 'preact/hooks';
 import SimulationView from './Simulation';
 import ScenarioView from './ScenarioView';
 import DocsView from './DocsView';
+import ShipView from './ShipView';
 
 export default function Root() {
-  const [tab, setTab] = useState<'sandbox' | 'scenario' | 'docs'>('sandbox');
+  const [tab, setTab] = useState<'sandbox' | 'scenario' | 'docs' | 'shipview'>('sandbox');
 
   return (
     <div className="app-root" style={{display:'flex', flexDirection:'column'}}>
@@ -17,11 +18,20 @@ export default function Root() {
         <div className="hud-buttons">
           <button onClick={() => setTab('sandbox')}>Sandbox</button>
           <button onClick={() => setTab('scenario')}>Scenario</button>
+          <button onClick={() => setTab('shipview')}>Shipview</button>
           <button onClick={() => setTab('docs')}>Docs</button>
         </div>
       </header>
       <main className="main-container">
-        {tab === 'sandbox' ? <SimulationView /> : tab === 'scenario' ? <ScenarioView /> : <DocsView />}
+        {tab === 'sandbox' ? (
+          <SimulationView />
+        ) : tab === 'scenario' ? (
+          <ScenarioView />
+        ) : tab === 'shipview' ? (
+          <ShipView />
+        ) : (
+          <DocsView />
+        )}
       </main>
       <footer className="status-footer">Ready</footer>
     </div>

--- a/spacesim/src/components/ShipView.tsx
+++ b/spacesim/src/components/ShipView.tsx
@@ -1,0 +1,16 @@
+import SimulationComponent from './Simulation';
+
+export default function ShipView() {
+  return (
+    <div className="shipview">
+      <div className="ship-cockpit">
+        <div className="ship-surface ship-left panel">Left</div>
+        <div className="ship-surface ship-window">
+          <SimulationComponent />
+        </div>
+        <div className="ship-surface ship-right panel">Right</div>
+      </div>
+      <div className="ship-surface ship-console panel">Console</div>
+    </div>
+  );
+}

--- a/spacesim/src/components/root.test.tsx
+++ b/spacesim/src/components/root.test.tsx
@@ -39,4 +39,12 @@ describe('Root', () => {
     expect(img).not.toBeNull();
     expect(img?.getAttribute('alt')).toBe('Spacesim logo');
   });
+
+  it('contains Shipview tab button', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<Root />, container);
+    const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Shipview');
+    expect(btn).not.toBeUndefined();
+  });
 });

--- a/spacesim/src/components/shipView.test.tsx
+++ b/spacesim/src/components/shipView.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from 'preact';
+
+vi.mock('./Simulation', () => ({ default: () => <div>sim</div> }));
+import ShipView from './ShipView';
+
+describe('ShipView', () => {
+  it('renders four cockpit surfaces', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<ShipView />, container);
+    const surfaces = container.querySelectorAll('.ship-surface');
+    expect(surfaces.length).toBe(4); // left, window, right, console
+    const consoleEl = container.querySelector('.ship-console');
+    expect(consoleEl).not.toBeNull();
+  });
+});

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -169,3 +169,45 @@ canvas {
   text-align: center;
   color: #0ff;
 }
+
+/* Ship cockpit layout */
+.shipview {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  perspective: 800px;
+}
+
+.ship-cockpit {
+  flex: 1;
+  display: flex;
+}
+
+.ship-surface {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #222;
+  border: 1px solid #0ff;
+  box-sizing: border-box;
+}
+
+.ship-window {
+  background: #000;
+}
+
+.ship-left {
+  transform: rotateY(15deg);
+}
+
+.ship-right {
+  transform: rotateY(-15deg);
+}
+
+.ship-console {
+  height: 100px;
+  border-top: 1px solid #0ff;
+  background: #111;
+}

--- a/spacesim/vitest.config.ts
+++ b/spacesim/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
     exclude: ['node_modules/**', 'e2e/**', 'performance/**'],
 
     coverage: {

--- a/spacesim/vitest.setup.ts
+++ b/spacesim/vitest.setup.ts
@@ -1,0 +1,8 @@
+if (!globalThis.requestAnimationFrame) {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 16) as unknown as number;
+  globalThis.cancelAnimationFrame = (id: number) => clearTimeout(id);
+}
+if (!performance.now) {
+  const start = Date.now();
+  performance.now = () => Date.now() - start;
+}


### PR DESCRIPTION
## Summary
- introduce `ShipView` cockpit component and add new tab
- style cockpit layout with retro theme
- test ship view structure and tab button
- document new feature in README and feature log
- setup Vitest to polyfill requestAnimationFrame

## Testing
- `npm test` *(fails: environment lacks necessary features)*

------
https://chatgpt.com/codex/tasks/task_e_68817b2722e48320abf71bd7c880d3e4