### PR TITLE
Add side rotation to shipview

### DIFF
--- a/feature/shipview/README.md
+++ b/feature/shipview/README.md
@@ -3,5 +3,8 @@
 - Added a new **Shipview** tab to the UI.
 - Presents a basic cockpit layout with three angled panels and a console.
 - The centre window is reserved for space imagery or the simulation.
+- Moving the mouse to either screen edge now rotates the cockpit.
+- The right side reveals a navigation screen running the simulation.
+- The left side shows an enlarged console panel.
 
 Tests: `spacesim/src/components/shipView.test.tsx` and `spacesim/src/components/root.test.tsx`.

--- a/spacesim/src/components/ShipView.tsx
+++ b/spacesim/src/components/ShipView.tsx
@@ -1,16 +1,32 @@
+import { useState } from 'preact/hooks';
 import SimulationComponent from './Simulation';
 
 export default function ShipView() {
+  const [view, setView] = useState<'center' | 'left' | 'right'>('center');
+
+  const onMove = (e: MouseEvent) => {
+    const edge = 50;
+    if (e.clientX < edge) setView('left');
+    else if (e.clientX > window.innerWidth - edge) setView('right');
+    else setView('center');
+  };
+
   return (
-    <div className="shipview">
+    <div className={`shipview view-${view}`} onMouseMove={onMove}>
       <div className="ship-cockpit">
-        <div className="ship-surface ship-left panel">Left</div>
+        <div className="ship-surface ship-left panel">Console</div>
         <div className="ship-surface ship-window">
           <SimulationComponent />
         </div>
-        <div className="ship-surface ship-right panel">Right</div>
+        <div className="ship-surface ship-right panel">Nav</div>
       </div>
       <div className="ship-surface ship-console panel">Console</div>
+      {view === 'left' && <div className="console-screen panel">Console</div>}
+      {view === 'right' && (
+        <div className="nav-screen panel">
+          <SimulationComponent />
+        </div>
+      )}
     </div>
   );
 }

--- a/spacesim/src/components/shipView.test.tsx
+++ b/spacesim/src/components/shipView.test.tsx
@@ -14,4 +14,18 @@ describe('ShipView', () => {
     const consoleEl = container.querySelector('.ship-console');
     expect(consoleEl).not.toBeNull();
   });
+
+  it('changes view on pointer move', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<ShipView />, container);
+    await Promise.resolve();
+    const rootEl = container.querySelector('.shipview') as HTMLElement;
+    rootEl.dispatchEvent(new MouseEvent('mousemove', { clientX: window.innerWidth - 1, bubbles: true }));
+    await new Promise(r => setTimeout(r, 0));
+    expect(rootEl.className).toContain('view-right');
+    rootEl.dispatchEvent(new MouseEvent('mousemove', { clientX: 0, bubbles: true }));
+    await new Promise(r => setTimeout(r, 0));
+    expect(rootEl.className).toContain('view-left');
+  });
 });

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -179,9 +179,18 @@ canvas {
   perspective: 800px;
 }
 
+.shipview.view-left .ship-cockpit {
+  transform: rotateY(20deg) translateX(20px);
+}
+
+.shipview.view-right .ship-cockpit {
+  transform: rotateY(-20deg) translateX(-20px);
+}
+
 .ship-cockpit {
   flex: 1;
   display: flex;
+  transition: transform 0.3s ease;
 }
 
 .ship-surface {
@@ -195,7 +204,13 @@ canvas {
 }
 
 .ship-window {
+  flex: 2;
   background: #000;
+}
+
+.ship-left,
+.ship-right {
+  flex: 0.66;
 }
 
 .ship-left {
@@ -207,7 +222,30 @@ canvas {
 }
 
 .ship-console {
-  height: 100px;
+  height: 70px;
   border-top: 1px solid #0ff;
   background: #111;
+}
+
+.console-screen,
+.nav-screen {
+  position: absolute;
+  bottom: 70px;
+  top: 10%;
+  width: 40%;
+  background: #111;
+  border: 1px solid #0ff;
+  box-shadow: 0 0 6px rgba(0, 255, 255, 0.5);
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.console-screen {
+  left: 0;
+}
+
+.nav-screen {
+  right: 0;
 }


### PR DESCRIPTION
## Summary
- expand shipview cockpit docs
- rotate shipview based on mouse position
- adjust cockpit layout styles and add side screens
- test pointer-driven rotation

## Testing
- `npm --prefix spacesim test`


------
https://chatgpt.com/codex/tasks/task_e_6881876ecca08320bd70b2d0d38f32d2