### PR TITLE
Fix gravity mass usage and realistic solar system

### DIFF
--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -14,6 +14,16 @@ describe('Sandbox gravity', () => {
     expect(b.body.getLinearVelocity().x).toBeLessThan(0);
   });
 
+  it('accelerates equal masses the same regardless of radius', () => {
+    const sb = new PhysicsEngine();
+    const a = sb.addBody(Vec2(-5, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: '' });
+    const b = sb.addBody(Vec2(5, 0), Vec2(), { mass: 1, radius: 2, color: 'blue', label: '' });
+    sb.step(1);
+    const velA = a.body.getLinearVelocity().x;
+    const velB = b.body.getLinearVelocity().x;
+    expect(Math.abs(velA)).toBeCloseTo(Math.abs(velB));
+  });
+
   it('clears bodies on reset', () => {
     const sb = new PhysicsEngine();
     sb.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: '' });
@@ -26,7 +36,8 @@ describe('Sandbox gravity', () => {
     const start = sb.addBody(Vec2(0, 0), Vec2(), { mass: 1, radius: 1, color: 'red', label: '' });
     if (start) sb.updateBody(start, { mass: 2 });
     const fixture = start?.body.getFixtureList();
-    expect(fixture?.getDensity()).toBe(2);
+    const expected = 2 / (Math.PI * 1 * 1);
+    expect(fixture?.getDensity()).toBeCloseTo(expected);
   });
 
   it('updates body radius', () => {
@@ -36,6 +47,8 @@ describe('Sandbox gravity', () => {
     const fixture = start?.body.getFixtureList();
     const shape = fixture?.getShape() as any;
     expect(shape.m_radius).toBe(2);
+    const expected = 1 / (Math.PI * 2 * 2);
+    expect(fixture?.getDensity()).toBeCloseTo(expected);
   });
 
   it('finds a body by position', () => {

--- a/spacesim/src/physics/engine.ts
+++ b/spacesim/src/physics/engine.ts
@@ -29,7 +29,8 @@ export class PhysicsEngine {
       position,
       linearVelocity: velocity,
     });
-    body.createFixture(planck.Circle(data.radius), { density: data.mass, isSensor: true });
+    const density = data.mass / (Math.PI * data.radius * data.radius);
+    body.createFixture(planck.Circle(data.radius), { density, isSensor: true });
     const entry = { body, data };
     this.bodies.push(entry);
     return entry;
@@ -58,22 +59,16 @@ export class PhysicsEngine {
     target: { body: planck.Body; data: BodyData },
     updates: Partial<BodyData> & { position?: Vec2; velocity?: Vec2 }
   ) {
-    if (updates.mass !== undefined) {
+    const newMass = updates.mass ?? target.data.mass;
+    const newRadius = updates.radius ?? target.data.radius;
+    if (updates.mass !== undefined || updates.radius !== undefined) {
       const fixture = target.body.getFixtureList();
-      if (fixture) {
-        fixture.setDensity(updates.mass);
-        target.body.resetMassData();
-      }
-      target.data.mass = updates.mass;
-    }
-    if (updates.radius !== undefined) {
-      const fixture = target.body.getFixtureList();
-      if (fixture) {
-        const density = fixture.getDensity();
-        target.body.destroyFixture(fixture);
-        target.body.createFixture(planck.Circle(updates.radius), { density });
-      }
-      target.data.radius = updates.radius;
+      if (fixture) target.body.destroyFixture(fixture);
+      const density = newMass / (Math.PI * newRadius * newRadius);
+      target.body.createFixture(planck.Circle(newRadius), { density });
+      target.body.resetMassData();
+      target.data.mass = newMass;
+      target.data.radius = newRadius;
     }
     if (updates.label !== undefined) target.data.label = updates.label;
     if (updates.color !== undefined) target.data.color = updates.color;

--- a/spacesim/src/scenarios/solarSystem.ts
+++ b/spacesim/src/scenarios/solarSystem.ts
@@ -7,62 +7,62 @@ export const solarSystem: ScenarioEvent[] = [
     action: 'addBody',
     position: Vec2(0, 0),
     velocity: Vec2(),
-    data: { mass: 1000, radius: 10, color: 'yellow', label: 'Sun' }
+    data: { mass: 99.4, radius: 7, color: 'yellow', label: 'Sun' }
   },
   {
     time: 0.1,
     action: 'addBody',
-    position: Vec2(40, 0),
-    velocity: Vec2(0, 4.8),
-    data: { mass: 0.055, radius: 1, color: 'gray', label: 'Mercury' }
+    position: Vec2(57.9, 0),
+    velocity: Vec2(0, 1.31),
+    data: { mass: 0.00002, radius: 1.2, color: 'gray', label: 'Mercury' }
   },
   {
     time: 0.1,
     action: 'addBody',
-    position: Vec2(70, 0),
-    velocity: Vec2(0, 3.5),
-    data: { mass: 0.815, radius: 2, color: 'orange', label: 'Venus' }
+    position: Vec2(76.5, 76.5),
+    velocity: Vec2(-0.68, 0.68),
+    data: { mass: 0.00024, radius: 3.0, color: 'orange', label: 'Venus' }
   },
   {
     time: 0.1,
     action: 'addBody',
-    position: Vec2(100, 0),
-    velocity: Vec2(0, 3),
-    data: { mass: 1, radius: 4, color: 'blue', label: 'Earth' }
+    position: Vec2(0, 149.6),
+    velocity: Vec2(-0.82, 0),
+    data: { mass: 0.00030, radius: 3.2, color: 'blue', label: 'Earth' }
   },
   {
     time: 0.1,
     action: 'addBody',
-    position: Vec2(150, 0),
-    velocity: Vec2(0, 2.4),
-    data: { mass: 0.107, radius: 2, color: 'red', label: 'Mars' }
+    position: Vec2(-161.1, 161.1),
+    velocity: Vec2(-0.47, -0.47),
+    data: { mass: 0.00003, radius: 1.7, color: 'red', label: 'Mars' }
   },
   {
     time: 0.2,
     action: 'addBody',
-    position: Vec2(300, 0),
-    velocity: Vec2(0, 1.5),
-    data: { mass: 317.8, radius: 6, color: 'orange', label: 'Jupiter' }
+    position: Vec2(-778.5, 0),
+    velocity: Vec2(0, -0.36),
+    data: { mass: 0.09490, radius: 4.9, color: 'orange', label: 'Jupiter' }
   },
   {
     time: 0.2,
     action: 'addBody',
-    position: Vec2(400, 0),
-    velocity: Vec2(0, 1.2),
-    data: { mass: 95, radius: 5, color: 'gold', label: 'Saturn' }
+    position: Vec2(-1013.6, -1013.6),
+    velocity: Vec2(0.19, -0.19),
+    data: { mass: 0.02842, radius: 4.1, color: 'gold', label: 'Saturn' }
   },
   {
     time: 0.2,
     action: 'addBody',
-    position: Vec2(500, 0),
-    velocity: Vec2(0, 1),
-    data: { mass: 14, radius: 4, color: 'lightblue', label: 'Uranus' }
+    position: Vec2(0, -2872.5),
+    velocity: Vec2(0.19, 0),
+    data: { mass: 0.00434, radius: 1.0, color: 'lightblue', label: 'Uranus' }
   },
   {
     time: 0.2,
     action: 'addBody',
-    position: Vec2(600, 0),
-    velocity: Vec2(0, 0.8),
-    data: { mass: 17, radius: 4, color: 'blue', label: 'Neptune' }
+    position: Vec2(3178.5, -3178.5),
+    velocity: Vec2(0.11, 0.11),
+    data: { mass: 0.00512, radius: 1.0, color: 'blue', label: 'Neptune' }
   }
 ];


### PR DESCRIPTION
## Summary
- compute fixture density from mass and radius
- make `updateBody` maintain physical mass
- give planets real masses, radii and starting orbits
- adjust physics tests for density logic

## Testing
- `npm --prefix spacesim test` *(passed)*
- `npm test` *(failed: playwright tried to install browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68818b02e2848320aa33baaa1dd5da1d