### PR TITLE
feat: add window view background

### DIFF
--- a/feature/window-view/README.md
+++ b/feature/window-view/README.md
@@ -1,0 +1,8 @@
+# Window View Background
+
+- Introduces `WindowView` component that sits in the ship cockpit window.
+- Large background image moves and rotates based on cockpit angle to fake 3D motion.
+- ShipView now embeds this component and passes its current view angle.
+- Styles allow oversize images so translation remains hidden.
+
+Tests: `spacesim/src/components/windowView.test.tsx`.

--- a/spacesim/src/components/ShipView.tsx
+++ b/spacesim/src/components/ShipView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import SimulationComponent from './Simulation';
+import WindowView from './WindowView';
 
 export default function ShipView() {
   const [view, setView] = useState<'center' | 'left' | 'right'>('center');
@@ -11,11 +12,14 @@ export default function ShipView() {
     else setView('center');
   };
 
+  const angle = view === 'left' ? 20 : view === 'right' ? -20 : 0;
+
   return (
     <div className={`shipview view-${view}`} onMouseMove={onMove}>
       <div className="ship-cockpit">
         <div className="ship-surface ship-left panel">Console</div>
-        <div className="ship-surface ship-window">
+        <div className="ship-surface ship-window" style={{ position:'relative' }}>
+          <WindowView angle={angle} />
           <SimulationComponent />
         </div>
         <div className="ship-surface ship-right panel">Nav</div>

--- a/spacesim/src/components/WindowView.tsx
+++ b/spacesim/src/components/WindowView.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+interface Props {
+  angle: number;
+}
+
+export default function WindowView({ angle }: Props) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const base = import.meta.env.BASE_URL;
+
+  useEffect(() => {
+    if (!imgRef.current) return;
+    const offset = angle * 2;
+    imgRef.current.style.transform = `translateX(${offset}px) rotate(${angle * 0.2}deg) scale(2)`;
+  }, [angle]);
+
+  return (
+    <div className="window-view">
+      <img
+        ref={imgRef}
+        src={`${base}images/logo.png`}
+        alt="Space background"
+        className="window-image"
+      />
+    </div>
+  );
+}

--- a/spacesim/src/components/windowView.test.tsx
+++ b/spacesim/src/components/windowView.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'preact';
+import WindowView from './WindowView';
+
+describe('WindowView', () => {
+  it('updates transform based on angle', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<WindowView angle={10} />, container);
+    await new Promise(r => setTimeout(r, 20));
+    const img = container.querySelector('.window-image') as HTMLElement;
+    expect(img.style.transform.length).toBeGreaterThan(0);
+    render(<WindowView angle={-10} />, container);
+    await new Promise(r => setTimeout(r, 20));
+    expect(img.style.transform).not.toBe('');
+  });
+});

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -208,6 +208,23 @@ canvas {
   background: #000;
 }
 
+/* WindowView styles */
+.window-view {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.window-image {
+  position: absolute;
+  top: -25%;
+  left: -25%;
+  width: 150%;
+  height: 150%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
 .ship-left,
 .ship-right {
   flex: 0.66;


### PR DESCRIPTION
## Summary
- create WindowView component that moves oversize background image
- embed WindowView in ShipView and update orientation logic
- style window image for parallax effect
- document feature

## Testing
- `npm test` *(fails: e2e tests require dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688190e148448320a0b76b6b873f7940