### PR TITLE
Implement orbital view in body editor

### DIFF
--- a/spacesim/src/components/BodyEditor.tsx
+++ b/spacesim/src/components/BodyEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { Simulation } from '../simulation';
-import { Vec3 } from '../vector';
 import type { BodyData } from '../physics';
+import { calcOrbitalParams } from '../orbitalParams';
 import {
   kgToUnits,
   unitsToKg,
@@ -18,32 +18,19 @@ interface Props {
   frame: number;
 }
 
-interface BodyState extends BodyData {
-  posX: number;
-  posY: number;
-  velX: number;
-  velY: number;
-}
+interface BodyState extends BodyData {}
 
 export default function BodyEditor({ sim, body, onDeselect, frame }: Props) {
   const [state, setState] = useState<BodyState | null>(() => {
     if (!body) return null;
-    const pos = body.body.position;
-    const vel = body.body.velocity;
-    return { ...body.data, posX: pos.x, posY: pos.y, velX: vel.x, velY: vel.y };
+    return { ...body.data };
   });
   const [edited, setEdited] = useState(false);
   useEffect(() => {
     if (!body) return setState(null);
     if (edited) return;
-    const pos = body.body.position;
-    const vel = body.body.velocity;
     setState({
       ...body.data,
-      posX: pos.x,
-      posY: pos.y,
-      velX: vel.x,
-      velY: vel.y,
     });
   }, [body, frame, edited]);
   if (!body || !state) return null;
@@ -55,8 +42,6 @@ export default function BodyEditor({ sim, body, onDeselect, frame }: Props) {
       radius: state.radius,
       color: state.color,
       label: state.label,
-      position: Vec3(state.posX, state.posY, 0),
-      velocity: Vec3(state.velX, state.velY, 0),
     });
   };
   const remove = () => {
@@ -85,10 +70,24 @@ export default function BodyEditor({ sim, body, onDeselect, frame }: Props) {
           onInput={e => { setEdited(true); setState({ ...state, radius: metersToUnits(parseFloat((e.target as HTMLInputElement).value)) }); }} />
       </label>
       <label>Color <input type="color" value={state.color} onInput={e => { setEdited(true); setState({ ...state, color: (e.target as HTMLInputElement).value }); }} /></label>
-      <label>Pos X (m) <input type="text" value={formatMeters(unitsToMeters(state.posX))} onInput={e => { setEdited(true); setState({ ...state, posX: metersToUnits(parseFloat((e.target as HTMLInputElement).value)) }); }} /></label>
-      <label>Pos Y (m) <input type="text" value={formatMeters(unitsToMeters(state.posY))} onInput={e => { setEdited(true); setState({ ...state, posY: metersToUnits(parseFloat((e.target as HTMLInputElement).value)) }); }} /></label>
-      <label>Vel X (m/s) <input type="text" value={formatMeters(unitsToMeters(state.velX))} onInput={e => { setEdited(true); setState({ ...state, velX: metersToUnits(parseFloat((e.target as HTMLInputElement).value)) }); }} /></label>
-      <label>Vel Y (m/s) <input type="text" value={formatMeters(unitsToMeters(state.velY))} onInput={e => { setEdited(true); setState({ ...state, velY: metersToUnits(parseFloat((e.target as HTMLInputElement).value)) }); }} /></label>
+      <div>
+        Parent: Sun
+      </div>
+      <div>
+        {(() => {
+          const parent = sim.bodies.find(b => b.data.label === 'Sun') ?? sim.bodies[0];
+          const p = calcOrbitalParams(body.body.position, body.body.velocity, parent.body.position, parent.data.mass, parent.data.radius);
+          return (
+            <>
+              <div>Height {formatMeters(unitsToMeters(p.height))}m</div>
+              <div>Speed {formatMeters(unitsToMeters(p.speed))}m/s</div>
+              <div>Apoapsis {p.apoapsis === Infinity ? '∞' : formatMeters(unitsToMeters(p.apoapsis))+'m'}</div>
+              <div>Periapsis {formatMeters(unitsToMeters(p.periapsis))}m</div>
+              <div>Inclination {p.inclination.toFixed(2)}°</div>
+            </>
+          );
+        })()}
+      </div>
       <button onClick={apply}>Apply</button>
       <button onClick={remove}>Delete</button>
     </div>

--- a/spacesim/src/components/bodyEditor.test.tsx
+++ b/spacesim/src/components/bodyEditor.test.tsx
@@ -1,45 +1,50 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from 'preact';
 import BodyEditor from './BodyEditor';
+import { Vec3 } from '../vector';
 
 const makeBody = (label: string) => ({
   data: { label, mass: 1, radius: 1, color: '#fff' },
-  body: { position: { x: 0, y: 0, z: 0 }, velocity: { x: 0, y: 0, z: 0 } } as any
+  body: { position: Vec3(), velocity: Vec3() }
 });
 
-const sim = {
+const makeSim = (sun: any, body: any) => ({
   updateBody: () => {},
-  removeBody: () => {}
-} as any;
+  removeBody: () => {},
+  bodies: [sun, body]
+} as any);
 
 describe('BodyEditor', () => {
   it('updates fields when body prop changes', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
-    render(<BodyEditor sim={sim} body={makeBody('a')} onDeselect={() => {}} frame={0} />, container);
+    const sun = makeBody('Sun');
+    const bodyA = makeBody('a');
+    const sim = makeSim(sun, bodyA);
+    render(<BodyEditor sim={sim} body={bodyA} onDeselect={() => {}} frame={0} />, container);
     const input = container.querySelector('input') as HTMLInputElement;
     expect(input.value).toBe('a');
     render(null, container);
-    render(<BodyEditor sim={sim} body={makeBody('b')} onDeselect={() => {}} frame={1} />, container);
+    const bodyB = makeBody('b');
+    const sim2 = makeSim(sun, bodyB);
+    render(<BodyEditor sim={sim2} body={bodyB} onDeselect={() => {}} frame={1} />, container);
     await new Promise(r => setTimeout(r));
     const input2 = container.querySelector('input') as HTMLInputElement;
     expect(input2.value).toBe('b');
   });
 
-  it('shows updated position each frame', async () => {
+  it('shows updated speed each frame', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
+    const sun = makeBody('Sun');
     const body = makeBody('a');
+    const sim = makeSim(sun, body);
     render(<BodyEditor sim={sim} body={body} onDeselect={() => {}} frame={0} />, container);
-    const labels = Array.from(container.querySelectorAll('label'));
-    const posX = labels.find(l => l.textContent?.startsWith('Pos X'))!.querySelector('input') as HTMLInputElement;
-    expect(posX.value).toBe('0.00e+0');
-    (body.body as any).position = { x: 2, y: 0, z: 0 };
+    expect(container.textContent).toContain('Speed 0.00e+0');
+    (body.body as any).velocity = Vec3(1, 0, 0);
     render(<BodyEditor sim={sim} body={body} onDeselect={() => {}} frame={1} />, container);
     await new Promise(r => setTimeout(r));
-    const labels2 = Array.from(container.querySelectorAll('label'));
-    const posX2 = labels2.find(l => l.textContent?.startsWith('Pos X'))!.querySelector('input') as HTMLInputElement;
-    expect(posX2.value).toBe('2.00e+9');
+    expect(container.textContent).toContain('Speed 1.00e+9');
   });
 
 });

--- a/spacesim/src/orbit.test.ts
+++ b/spacesim/src/orbit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { PhysicsEngine, G } from './physics';
-import { Vec3 } from './vector';
+import { Vec3, distance } from './vector';
 import { simulateOrbit, ESCAPE_RADIUS } from './orbit';
 import { throwVelocity, predictOrbitType } from './utils';
 
@@ -27,7 +27,7 @@ describe('simulateOrbit', () => {
     const first = pts[0];
     const last = pts[pts.length-1];
     expect(pts.length).toBeGreaterThan(300);
-    expect(Vec3.distance(first, last)).toBeLessThan(0.5);
+    expect(distance(first, last)).toBeLessThan(0.5);
   });
 
   it('stops when crashing', () => {
@@ -35,7 +35,7 @@ describe('simulateOrbit', () => {
     const type = predictOrbitType(Vec3(10,0,0), vel, centralPos, mass, radius, G);
     const pts = simulateOrbit(Vec3(10,0,0), vel, centralPos, mass, radius, type);
     const last = pts[pts.length-1];
-    expect(Vec3.distance(last, centralPos)).toBeLessThanOrEqual(radius);
+    expect(distance(last, centralPos)).toBeLessThanOrEqual(radius);
   });
 
   it('stops after leaving sphere of influence', () => {
@@ -43,6 +43,6 @@ describe('simulateOrbit', () => {
     const type = predictOrbitType(Vec3(10,0,0), vel, centralPos, mass, radius, G);
     const pts = simulateOrbit(Vec3(10,0,0), vel, centralPos, mass, radius, type);
     const last = pts[pts.length-1];
-    expect(Vec3.distance(last, centralPos)).toBeGreaterThanOrEqual(ESCAPE_RADIUS);
+    expect(distance(last, centralPos)).toBeGreaterThanOrEqual(ESCAPE_RADIUS);
   });
 });

--- a/spacesim/src/orbitalParams.test.ts
+++ b/spacesim/src/orbitalParams.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { Vec3 } from './vector';
+import { calcOrbitalParams } from './orbitalParams';
+
+// central body at origin with mass 1 and radius 1
+const parentPos = Vec3(0,0,0);
+const parentMass = 1;
+const parentRadius = 1;
+
+describe('calcOrbitalParams', () => {
+  it('computes circular orbit parameters', () => {
+    const pos = Vec3(10,0,0);
+    const mu = 1; // G * mass = 1 since G=1 and mass=1
+    const v = Math.sqrt(mu / pos.length());
+    const params = calcOrbitalParams(pos, Vec3(0,v,0), parentPos, parentMass, parentRadius);
+    expect(params.height).toBeCloseTo(9);
+    expect(params.speed).toBeCloseTo(v);
+    expect(params.apoapsis).toBeCloseTo(9);
+    expect(params.periapsis).toBeCloseTo(9);
+    expect(params.inclination).toBeCloseTo(0);
+  });
+});

--- a/spacesim/src/orbitalParams.ts
+++ b/spacesim/src/orbitalParams.ts
@@ -1,0 +1,38 @@
+import { Vec3 } from './vector';
+import { G } from './physics';
+
+export interface OrbitalParams {
+  height: number;
+  speed: number;
+  apoapsis: number;
+  periapsis: number;
+  inclination: number;
+}
+
+export function calcOrbitalParams(
+  pos: Vec3,
+  vel: Vec3,
+  parentPos: Vec3,
+  parentMass: number,
+  parentRadius: number
+): OrbitalParams {
+  const rVec = pos.clone().sub(parentPos);
+  const vVec = vel.clone();
+  const r = rVec.length();
+  const v = vVec.length();
+  const height = r - parentRadius;
+  const mu = G * parentMass;
+  const energy = 0.5 * v * v - mu / r;
+  const hVec = rVec.clone().cross(vVec);
+  const h = hVec.length();
+  let a = Infinity;
+  let e = 0;
+  if (energy < 0 && h !== 0) {
+    a = -mu / (2 * energy);
+    e = Math.sqrt(Math.max(0, 1 + (2 * energy * h * h) / (mu * mu)));
+  }
+  const apoapsis = a === Infinity ? Infinity : a * (1 + e) - parentRadius;
+  const periapsis = a === Infinity ? height : a * (1 - e) - parentRadius;
+  const inclination = h === 0 ? 0 : Math.acos(hVec.z / h) * (180 / Math.PI);
+  return { height, speed: v, apoapsis, periapsis, inclination };
+}

--- a/spacesim/src/simulation.ts
+++ b/spacesim/src/simulation.ts
@@ -28,8 +28,7 @@ export class Simulation {
   private scenario?: ScenarioEvent[];
   private canvas?: HTMLCanvasElement;
 
-  private _view = { center: Vec2(), zoom: 1, rotation: 0 };
-  private _view = { center: Vec3(), zoom: 1 };
+  private _view = { center: Vec3(), zoom: 1, rotation: 0 };
 
   private overlay?: { start: Vec3; end: Vec3 } | null;
 


### PR DESCRIPTION
## Summary
- compute orbital parameters for bodies
- display height, speed and orbit info in the body editor
- test orbital parameter calculations
- update body editor tests for new view
- fix simulation view configuration

## Testing
- `npm test` *(fails: 14 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68819c762a648320b968c7f0008fd3d1