### PR TITLE
Adjust ship view UI

### DIFF
--- a/spacesim/src/components/ShipView.tsx
+++ b/spacesim/src/components/ShipView.tsx
@@ -13,7 +13,7 @@ export default function ShipView() {
     else setView('center');
   };
 
-  const angle = view === 'left' ? 20 : view === 'right' ? -20 : 0;
+  const angle = view === 'left' ? -20 : view === 'right' ? 20 : 0;
 
   return (
     <div className={`shipview view-${view}`} onMouseMove={onMove}>
@@ -21,12 +21,18 @@ export default function ShipView() {
         <div className="ship-surface ship-left panel">Console</div>
         <div className="ship-surface ship-window" style={{ position:'relative' }}>
           <WindowView angle={angle} />
-          <SimulationComponent />
         </div>
-        <div className="ship-surface ship-right panel">Nav</div>
+        <div className="ship-surface ship-right panel">
+          {view !== 'right' && <div className="nav-static" />}
+          Nav
+        </div>
       </div>
       <div className="ship-surface ship-console panel">Console</div>
-      {view === 'left' && <div className="console-screen panel">Console</div>}
+      {view === 'left' && (
+        <div className="console-screen panel">
+          <SimulationComponent showSpawner={false} />
+        </div>
+      )}
       {view === 'right' && (
         <div className="nav-screen panel">
           <NavigationView />

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -11,9 +11,10 @@ import { uniqueName, throwVelocity, nextSpawnParams } from '../utils';
 interface Props {
   scenario?: ScenarioEvent[];
   sim?: Simulation; // for tests
+  showSpawner?: boolean;
 }
 
-export default function SimulationComponent({ scenario, sim: ext }: Props) {
+export default function SimulationComponent({ scenario, sim: ext, showSpawner = true }: Props) {
   const [sim] = useState(() => ext ?? new Simulation());
   useEffect(() => {
     if (import.meta.env.DEV) {
@@ -132,7 +133,14 @@ export default function SimulationComponent({ scenario, sim: ext }: Props) {
         </div>
         <div className="sim-time" style={{marginTop:'0.25rem'}}>Time {time.toFixed(1)}s</div>
       </div>
-      <BodySpawner sim={sim} disabled={!!selected || !!dragStart} params={spawnParams} onChange={setSpawnParams} />
+      {showSpawner && (
+        <BodySpawner
+          sim={sim}
+          disabled={!!selected || !!dragStart}
+          params={spawnParams}
+          onChange={setSpawnParams}
+        />
+      )}
       <BodyEditor sim={sim} body={selected} onDeselect={()=>setSelected(null)} frame={frame} />
       <BodyList sim={sim} selected={selected} onSelect={b=>setSelected(b)} />
       <BodyLabels sim={sim} frame={frame} />

--- a/spacesim/src/components/shipView.test.tsx
+++ b/spacesim/src/components/shipView.test.tsx
@@ -29,4 +29,16 @@ describe('ShipView', () => {
     await new Promise(r => setTimeout(r, 0));
     expect(rootEl.className).toContain('view-left');
   });
+
+  it('shows simulation in console screen when view is left', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<ShipView />, container);
+    await Promise.resolve();
+    const rootEl = container.querySelector('.shipview') as HTMLElement;
+    rootEl.dispatchEvent(new MouseEvent('mousemove', { clientX: 0, bubbles: true }));
+    await new Promise(r => setTimeout(r, 0));
+    const screen = container.querySelector('.console-screen');
+    expect(screen?.textContent).toContain('sim');
+  });
 });

--- a/spacesim/src/components/simulationComponent.test.tsx
+++ b/spacesim/src/components/simulationComponent.test.tsx
@@ -54,4 +54,11 @@ describe('SimulationComponent', () => {
     display = container.querySelector('.sim-time') as HTMLElement
     expect(display.textContent).toBe('Time 1.5s')
   })
+
+  it('hides spawner when showSpawner is false', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    render(<SimulationComponent sim={sim} showSpawner={false} />, container)
+    expect(container.textContent).not.toContain('Click canvas to spawn')
+  })
 })

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -180,11 +180,11 @@ canvas {
 }
 
 .shipview.view-left .ship-cockpit {
-  transform: rotateY(20deg) translateX(20px);
+  transform: rotateY(-20deg) translateX(-20px) scale(0.95);
 }
 
 .shipview.view-right .ship-cockpit {
-  transform: rotateY(-20deg) translateX(-20px);
+  transform: rotateY(20deg) translateX(20px) scale(0.95);
 }
 
 .ship-cockpit {
@@ -204,7 +204,7 @@ canvas {
 }
 
 .ship-window {
-  flex: 2;
+  flex: 2.4;
   background: #000;
 }
 
@@ -217,10 +217,10 @@ canvas {
 
 .window-image {
   position: absolute;
-  top: -25%;
+  top: -20%;
   left: -25%;
   width: 150%;
-  height: 150%;
+  height: 160%;
   object-fit: cover;
   transition: transform 0.3s ease;
 }
@@ -231,15 +231,16 @@ canvas {
 }
 
 .ship-left {
-  transform: rotateY(15deg);
+  transform: rotateY(15deg) skewY(-2deg);
 }
 
 .ship-right {
-  transform: rotateY(-15deg);
+  position: relative;
+  transform: rotateY(-15deg) skewY(2deg);
 }
 
 .ship-console {
-  height: 70px;
+  height: 60px;
   border-top: 1px solid #0ff;
   background: #111;
 }
@@ -247,8 +248,6 @@ canvas {
 .console-screen,
 .nav-screen {
   position: absolute;
-  bottom: 70px;
-  top: 10%;
   width: 40%;
   background: #111;
   border: 1px solid #0ff;
@@ -261,8 +260,26 @@ canvas {
 
 .console-screen {
   left: 0;
+  bottom: 60px;
+  height: 40%;
 }
 
 .nav-screen {
   right: 0;
+  top: 0;
+  height: 40%;
+}
+
+.nav-static {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.6;
+  background-image: repeating-linear-gradient(
+    0deg,
+    #111 0px,
+    #222 2px,
+    #333 3px,
+    #222 4px
+  );
 }


### PR DESCRIPTION
## Summary
- hide body spawner inside ship view
- put simulation in left console popup
- show navigation placeholder when closed
- tweak cockpit angles and proportions for perspective
- cover these changes with unit tests

## Testing
- `npm test` *(fails: PhysicsEngine tests require planck)*

------
https://chatgpt.com/codex/tasks/task_e_68819fedf70c8320a2d775dacbdfff94