### PR TITLE
Fix shipview edges when turning

### DIFF
--- a/spacesim/src/components/ShipView.tsx
+++ b/spacesim/src/components/ShipView.tsx
@@ -2,6 +2,7 @@ import { useState } from 'preact/hooks';
 import NavigationView from './NavigationView';
 import BurnControls from './BurnControls';
 import WindowView from './WindowView';
+import SimulationComponent from './Simulation';
 
 export default function ShipView() {
   const [view, setView] = useState<'center' | 'left' | 'right'>('center');

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -177,6 +177,15 @@ canvas {
   display: flex;
   flex-direction: column;
   perspective: 800px;
+  overflow: hidden;
+}
+
+.shipview::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 20px 30px #000;
 }
 
 .shipview.view-left .ship-cockpit {


### PR DESCRIPTION
## Summary
- mask top corners of ship cockpit so they stay dark while turning
- import `SimulationComponent` in `ShipView` to fix runtime error

## Testing
- `npm test` *(fails: Error creating WebGL context)*

------
https://chatgpt.com/codex/tasks/task_e_6881b008d4d48320ba32262a36477113