### PR TITLE
feat: add wsad thruster controls

### DIFF
--- a/feature/wsad-thrusters/README.md
+++ b/feature/wsad-thrusters/README.md
@@ -1,0 +1,9 @@
+# WSAD Thruster Controls
+
+- Adds keyboard controls that simulate small thrusters using the WSAD keys.
+- Holding a key gradually increases rotational velocity and the ship continues
+  to spin until counter-thrust is applied.
+- `WindowView` now accepts yaw and pitch to render an endless star field that
+  moves with the ship.
+- Stars come from `images/hdr_stars.jpeg` and repeat at the edges to fake depth.
+- Tests cover the new transformation logic and basic keyboard rotation.

--- a/spacesim/src/components/ShipView.tsx
+++ b/spacesim/src/components/ShipView.tsx
@@ -1,10 +1,47 @@
-import { useState } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import NavigationView from './NavigationView';
 import BurnControls from './BurnControls';
 import WindowView from './WindowView';
 
 export default function ShipView() {
   const [view, setView] = useState<'center' | 'left' | 'right'>('center');
+  const [yaw, setYaw] = useState(0);
+  const [pitch, setPitch] = useState(0);
+  const vel = useRef({ yaw: 0, pitch: 0 });
+  const keys = useRef({ w:false, a:false, s:false, d:false });
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === 'w') keys.current.w = true;
+      else if (e.key === 's') keys.current.s = true;
+      else if (e.key === 'a') keys.current.a = true;
+      else if (e.key === 'd') keys.current.d = true;
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.key === 'w') keys.current.w = false;
+      else if (e.key === 's') keys.current.s = false;
+      else if (e.key === 'a') keys.current.a = false;
+      else if (e.key === 'd') keys.current.d = false;
+    };
+    window.addEventListener('keydown', down);
+    window.addEventListener('keyup', up);
+    let frame: number;
+    const step = () => {
+      if (keys.current.w) vel.current.pitch -= 0.0005;
+      if (keys.current.s) vel.current.pitch += 0.0005;
+      if (keys.current.a) vel.current.yaw += 0.0005;
+      if (keys.current.d) vel.current.yaw -= 0.0005;
+      setYaw(y => y + vel.current.yaw);
+      setPitch(p => p + vel.current.pitch);
+      frame = requestAnimationFrame(step);
+    };
+    frame = requestAnimationFrame(step);
+    return () => {
+      window.removeEventListener('keydown', down);
+      window.removeEventListener('keyup', up);
+      cancelAnimationFrame(frame);
+    };
+  }, []);
 
   const onMove = (e: MouseEvent) => {
     const edge = 50;
@@ -20,7 +57,7 @@ export default function ShipView() {
       <div className="ship-cockpit">
         <div className="ship-surface ship-left panel">Console</div>
         <div className="ship-surface ship-window" style={{ position:'relative' }}>
-          <WindowView angle={angle} />
+          <WindowView yaw={angle + yaw * 57.3} pitch={pitch * 57.3} />
           <NavigationView />
         </div>
         <div className="ship-surface ship-right panel">

--- a/spacesim/src/components/WindowView.tsx
+++ b/spacesim/src/components/WindowView.tsx
@@ -1,26 +1,28 @@
 import { useEffect, useRef } from 'preact/hooks';
 
 interface Props {
-  angle: number;
+  yaw: number;
+  pitch: number;
 }
 
-export default function WindowView({ angle }: Props) {
-  const imgRef = useRef<HTMLImageElement>(null);
+export default function WindowView({ yaw, pitch }: Props) {
+  const imgRef = useRef<HTMLDivElement>(null);
   const base = import.meta.env.BASE_URL;
 
   useEffect(() => {
     if (!imgRef.current) return;
-    const offset = angle * 2;
-    imgRef.current.style.transform = `translateX(${offset}px) rotate(${angle * 0.2}deg) scale(2)`;
-  }, [angle]);
+    const offX = yaw * 2;
+    const offY = pitch * 2;
+    imgRef.current.style.transform = `translate(${offX}px, ${offY}px) rotate(${yaw * 0.2}deg) scale(2)`;
+    imgRef.current.style.backgroundPosition = `${-offX}px ${-offY}px`;
+  }, [yaw, pitch]);
 
   return (
     <div className="window-view">
-      <img
+      <div
         ref={imgRef}
-        src={`${base}images/logo.png`}
-        alt="Space background"
         className="window-image"
+        style={{ backgroundImage: `url(${base}images/hdr_stars.jpeg)` }}
       />
     </div>
   );

--- a/spacesim/src/components/shipView.test.tsx
+++ b/spacesim/src/components/shipView.test.tsx
@@ -41,4 +41,20 @@ describe('ShipView', () => {
     const screen = container.querySelector('.console-screen');
     expect(screen?.textContent).toContain('sim');
   });
+
+  it('rotates window when pressing D', async () => {
+    vi.useFakeTimers();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<ShipView />, container);
+    await Promise.resolve();
+    const img = container.querySelector('.window-image') as HTMLElement;
+    const initial = img.style.transform;
+    window.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'd', bubbles: true }));
+    vi.advanceTimersByTime(20);
+    window.dispatchEvent(new window.KeyboardEvent('keyup', { key: 'd', bubbles: true }));
+    vi.advanceTimersByTime(40);
+    expect(img.style.transform).not.toBe(initial);
+    vi.useRealTimers();
+  });
 });

--- a/spacesim/src/components/windowView.test.tsx
+++ b/spacesim/src/components/windowView.test.tsx
@@ -3,14 +3,14 @@ import { render } from 'preact';
 import WindowView from './WindowView';
 
 describe('WindowView', () => {
-  it('updates transform based on angle', async () => {
+  it('updates transform based on yaw', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
-    render(<WindowView angle={10} />, container);
+    render(<WindowView yaw={10} pitch={0} />, container);
     await new Promise(r => setTimeout(r, 50));
     const img = container.querySelector('.window-image') as HTMLElement;
     expect(img.style.transform.length).toBeGreaterThan(0);
-    render(<WindowView angle={-10} />, container);
+    render(<WindowView yaw={-10} pitch={0} />, container);
     await new Promise(r => setTimeout(r, 50));
     expect(img.style.transform).not.toBe('');
   });

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -217,12 +217,13 @@ canvas {
 
 .window-image {
   position: absolute;
-  top: -20%;
-  left: -25%;
-  width: 150%;
-  height: 160%;
-  object-fit: cover;
-  transition: transform 0.3s ease;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background-size: 512px 512px;
+  background-repeat: repeat;
+  transition: transform 0.3s ease, background-position 0.3s linear;
 }
 
 .ship-left,


### PR DESCRIPTION
## Summary
- add simple WSAD thrusters that keep rotating the ship
- swap window stars for hdr_stars background and repeat edges
- adapt tests for new window props and add basic keyboard rotation check

## Testing
- `npm test` *(fails: HTMLCanvasElement.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_6881b37db1b0832095e950ce4fa964c4