### PR TITLE
Implement heuristic collision energy

### DIFF
--- a/spacesim/src/physics.test.ts
+++ b/spacesim/src/physics.test.ts
@@ -60,11 +60,13 @@ describe('Sandbox gravity', () => {
     expect(found).toBeUndefined();
   });
 
-  it('merges smaller body on collision with massive one', () => {
+  it('slowly merges smaller body into massive one', () => {
     const sb = new PhysicsEngine();
     const big = sb.addBody(Vec3(0, 0), Vec3(), { mass: 3, radius: 1, color: 'red', label: '' });
     const small = sb.addBody(Vec3(0.5, 0), Vec3(), { mass: 1, radius: 1, color: 'blue', label: '' });
     sb.step(0);
+    expect(sb.bodies.length).toBe(2);
+    sb.step(1);
     expect(sb.bodies.length).toBe(1);
     expect(sb.bodies[0].data.mass).toBeCloseTo(4);
   });

--- a/spacesim/src/physics/engine.ts
+++ b/spacesim/src/physics/engine.ts
@@ -1,5 +1,27 @@
 import { Vec3 } from '../vector';
 
+function hexToRgb(hex: string) {
+  const n = parseInt(hex.slice(1), 16);
+  return {
+    r: (n >> 16) & 0xff,
+    g: (n >> 8) & 0xff,
+    b: n & 0xff,
+  };
+}
+
+function rgbToHex({ r, g, b }: { r: number; g: number; b: number }) {
+  const n = (r << 16) | (g << 8) | b;
+  return `#${n.toString(16).padStart(6, '0')}`;
+}
+
+function blendToRed(color: string, t: number) {
+  const rgb = hexToRgb(color);
+  const r = Math.round(rgb.r + (255 - rgb.r) * t);
+  const g = Math.round(rgb.g * (1 - t));
+  const b = Math.round(rgb.b * (1 - t));
+  return rgbToHex({ r, g, b });
+}
+
 export interface BodyData {
   mass: number;
   radius: number;
@@ -19,8 +41,30 @@ export interface Body {
 
 export const G = 1; // gravitational constant (arbitrary units)
 
+function collisionEnergy(a: { body: Body; data: BodyData }, b: { body: Body; data: BodyData }, n: Vec3) {
+  const rel = b.body.velocity.clone().sub(a.body.velocity);
+  const speed = rel.length();
+  const mu = (a.data.mass * b.data.mass) / (a.data.mass + b.data.mass);
+  const angle = Math.abs(rel.normalize().dot(n.clone().normalize()));
+  const vol = (4 / 3) * Math.PI;
+  const d1 = a.data.mass / (vol * Math.pow(a.data.radius, 3));
+  const d2 = b.data.mass / (vol * Math.pow(b.data.radius, 3));
+  const densityFactor = (d1 + d2) / 2;
+  return 0.5 * mu * speed * speed * densityFactor * angle;
+}
+
 export class PhysicsEngine {
   public bodies: { body: Body; data: BodyData }[] = [];
+  private merges: {
+    big: { body: Body; data: BodyData };
+    small: { body: Body; data: BodyData };
+    elapsed: number;
+    duration: number;
+    bigMass: number;
+    bigRadius: number;
+    smallMass: number;
+    smallRadius: number;
+  }[] = [];
 
   addBody(position: Vec3, velocity: Vec3, data: BodyData) {
     const body: Body = { position: position.clone(), velocity: velocity.clone() };
@@ -43,8 +87,6 @@ export class PhysicsEngine {
   }
 
   updateBody(target: { body: Body; data: BodyData }, updates: BodyUpdate) {
-    target: { body: Body; data: BodyData },
-  ) {
     if (updates.mass !== undefined) target.data.mass = updates.mass;
     if (updates.radius !== undefined) target.data.radius = updates.radius;
     if (updates.label !== undefined) target.data.label = updates.label;
@@ -73,18 +115,17 @@ export class PhysicsEngine {
   }
 
   private mergeBodies(big: { body: Body; data: BodyData }, small: { body: Body; data: BodyData }) {
-    const m1 = big.data.mass;
-    const m2 = small.data.mass;
-    const total = m1 + m2;
-    const pos = big.body.position.clone().multiplyScalar(m1)
-      .add(small.body.position.clone().multiplyScalar(m2))
-      .multiplyScalar(1 / total);
-    const vel = big.body.velocity.clone().multiplyScalar(m1)
-      .add(small.body.velocity.clone().multiplyScalar(m2))
-      .multiplyScalar(1 / total);
-    const radius = Math.sqrt(big.data.radius * big.data.radius + small.data.radius * small.data.radius);
-    this.updateBody(big, { mass: total, radius, position: pos, velocity: vel });
-    this.removeBody(small);
+    const duration = 1; // seconds
+    this.merges.push({
+      big,
+      small,
+      elapsed: 0,
+      duration,
+      bigMass: big.data.mass,
+      bigRadius: big.data.radius,
+      smallMass: small.data.mass,
+      smallRadius: small.data.radius,
+    });
   }
 
   private bounceBodies(a: { body: Body; data: BodyData }, b: { body: Body; data: BodyData }, n: Vec3, dist: number) {
@@ -108,6 +149,24 @@ export class PhysicsEngine {
     b.body.position.add(unit.clone().multiplyScalar(overlap));
   }
 
+  private updateMerges(dt: number) {
+    for (let i = this.merges.length - 1; i >= 0; i--) {
+      const m = this.merges[i];
+      m.elapsed += dt;
+      const t = Math.min(m.elapsed / m.duration, 1);
+      const bigMass = m.bigMass + m.smallMass * t;
+      const bigRadius = Math.sqrt(m.bigRadius * m.bigRadius + m.smallRadius * m.smallRadius * t);
+      const smallMass = m.smallMass * (1 - t);
+      const smallRadius = m.smallRadius * (1 - t);
+      this.updateBody(m.big, { mass: bigMass, radius: bigRadius });
+      this.updateBody(m.small, { mass: smallMass, radius: smallRadius });
+      if (t >= 1) {
+        this.removeBody(m.small);
+        this.merges.splice(i, 1);
+      }
+    }
+  }
+
   private resolveCollisions() {
     for (let i = 0; i < this.bodies.length; i++) {
       for (let j = i + 1; j < this.bodies.length; j++) {
@@ -119,14 +178,26 @@ export class PhysicsEngine {
         if (dist >= targetDist || dist === 0) continue;
         const m1 = a.data.mass;
         const m2 = b.data.mass;
-        if (m1 >= m2 * 3) {
-          this.mergeBodies(a, b);
+        const energy = collisionEnergy(a, b, n);
+        const angle = Math.abs(b.body.velocity.clone().sub(a.body.velocity).normalize().dot(n.clone().normalize()));
+        const glancing = angle < 0.3;
+        if (!glancing && energy > 20) {
+          // violent clash -> color shift
+          a.data.color = blendToRed(a.data.color, 0.8);
+          b.data.color = blendToRed(b.data.color, 0.8);
+          this.mergeBodies(m1 > m2 ? a : b, m1 > m2 ? b : a);
           j--;
-        } else if (m2 >= m1 * 3) {
-          this.mergeBodies(b, a);
+        } else if (m1 >= m2 * 3 || m2 >= m1 * 3 || energy < 5) {
+          const big = m1 >= m2 ? a : b;
+          const small = big === a ? b : a;
+          big.data.color = blendToRed(big.data.color, Math.min(1, energy / 20));
+          small.data.color = blendToRed(small.data.color, Math.min(1, energy / 20));
+          this.mergeBodies(big, small);
           j--;
         } else {
           this.bounceBodies(a, b, n, dist);
+          a.data.color = blendToRed(a.data.color, Math.min(1, energy / 20));
+          b.data.color = blendToRed(b.data.color, Math.min(1, energy / 20));
         }
       }
     }
@@ -137,6 +208,7 @@ export class PhysicsEngine {
     for (const obj of this.bodies) {
       obj.body.position.add(obj.body.velocity.clone().multiplyScalar(dt));
     }
+    this.updateMerges(dt);
     this.resolveCollisions();
   }
 }


### PR DESCRIPTION
## Summary
- improve physics engine with energy-based collision heuristic
- blend body color to red based on impact energy and slowly merge bodies
- update PhysicsEngine tests for new merge logic

## Testing
- `npm test` *(fails: Node OOM)*

------
https://chatgpt.com/codex/tasks/task_e_6881ba2745948320b7618a38c7066150