### PR TITLE
Add draggable test view

### DIFF
--- a/feature/README.md
+++ b/feature/README.md
@@ -27,5 +27,6 @@ Create a folder here for each significant feature. Document:
 - [Metric Units](metric-units/README.md)
 - [Navigation View Rotation](navigation-view/README.md)
 - [Ship Navigation Burn Controls](burn-controls/README.md)
+- [Test View Sandbox](test-view/README.md)
 
 Each user-facing feature includes an accompanying end-to-end test referenced in its documentation.

--- a/feature/test-view/README.md
+++ b/feature/test-view/README.md
@@ -1,0 +1,6 @@
+# Test View Sandbox
+
+- Adds a new **Test** tab accessible from the utilities menu.
+- TestView shows draggable elements that can be locked in place.
+- Layout can be saved to and loaded from browser storage.
+- Unit tests verify layout loading and lock toggling.

--- a/spacesim/src/components/Draggable.tsx
+++ b/spacesim/src/components/Draggable.tsx
@@ -1,0 +1,44 @@
+import { useRef, useState } from 'preact/hooks';
+
+interface Props {
+  id: string;
+  locked: boolean;
+  pos: { x: number; y: number };
+  onMove: (id: string, x: number, y: number) => void;
+  children: preact.ComponentChildren;
+}
+
+export default function Draggable({ id, locked, pos, onMove, children }: Props) {
+  const [offset, setOffset] = useState<{ x: number; y: number } | null>(null);
+  const start = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  const down = (e: MouseEvent) => {
+    if (locked) return;
+    start.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+    setOffset({ x: pos.x, y: pos.y });
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  const move = (e: MouseEvent) => {
+    if (!offset) return;
+    onMove(id, e.clientX - start.current.x, e.clientY - start.current.y);
+  };
+
+  const up = () => {
+    setOffset(null);
+    window.removeEventListener('mousemove', move);
+    window.removeEventListener('mouseup', up);
+  };
+
+  return (
+    <div
+      data-id={id}
+      className="draggable"
+      style={{ position: 'absolute', left: pos.x, top: pos.y, cursor: locked ? 'default' : 'move' }}
+      onMouseDown={down}
+    >
+      {children}
+    </div>
+  );
+}

--- a/spacesim/src/components/Root.tsx
+++ b/spacesim/src/components/Root.tsx
@@ -2,9 +2,10 @@ import { useState } from 'preact/hooks';
 import SimulationView from './Simulation';
 import DocsView from './DocsView';
 import ShipView from './ShipView';
+import TestView from './TestView';
 
 export default function Root() {
-  const [tab, setTab] = useState<'sandbox' | 'scenario' | 'docs' | 'shipview'>('sandbox');
+  const [tab, setTab] = useState<'sandbox' | 'scenario' | 'docs' | 'shipview' | 'test'>('sandbox');
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
@@ -21,6 +22,8 @@ export default function Root() {
           <SimulationView />
         ) : tab === 'shipview' ? (
           <ShipView />
+        ) : tab === 'test' ? (
+          <TestView />
         ) : (
           <DocsView />
         )}
@@ -35,6 +38,7 @@ export default function Root() {
           <button onClick={() => { setTab('scenario'); setMenuOpen(false); }}>Scenario</button>
           <button onClick={() => { setTab('shipview'); setMenuOpen(false); }}>Shipview</button>
           <button onClick={() => { setTab('docs'); setMenuOpen(false); }}>Docs</button>
+          <button onClick={() => { setTab('test'); setMenuOpen(false); }}>Test</button>
         </div>
       </div>
     </div>

--- a/spacesim/src/components/TestView.tsx
+++ b/spacesim/src/components/TestView.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'preact/hooks';
+import Draggable from './Draggable';
+
+interface Layout { [id: string]: { x: number; y: number } }
+const STORAGE_KEY = 'test-layout';
+
+const defaultLayout: Layout = {
+  a: { x: 20, y: 80 },
+  b: { x: 160, y: 80 },
+  c: { x: 20, y: 160 },
+};
+
+export default function TestView() {
+  const [layout, setLayout] = useState<Layout>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : defaultLayout;
+  });
+  const [locked, setLocked] = useState(true);
+
+  const move = (id: string, x: number, y: number) => {
+    setLayout(l => ({ ...l, [id]: { x, y } }));
+  };
+
+  const save = () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+  };
+
+  const load = () => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) setLayout(JSON.parse(stored));
+  };
+
+  return (
+    <div className="test-view" style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <button
+        className="lock-toggle"
+        data-locked={locked}
+        style={{ position: 'absolute', top: 10, left: 10, background: locked ? 'red' : 'green' }}
+        onClick={() => setLocked(l => !l)}
+      >
+        Lock
+      </button>
+      <button style={{ position: 'absolute', top: 10, left: 70 }} onClick={save}>Save</button>
+      <button style={{ position: 'absolute', top: 10, left: 130 }} onClick={load}>Load</button>
+      <Draggable id="a" locked={locked} pos={layout.a} onMove={move}>
+        <button>A</button>
+      </Draggable>
+      <Draggable id="b" locked={locked} pos={layout.b} onMove={move}>
+        <button>B</button>
+      </Draggable>
+      <Draggable id="c" locked={locked} pos={layout.c} onMove={move}>
+        <input placeholder="type" />
+      </Draggable>
+    </div>
+  );
+}

--- a/spacesim/src/components/testView.test.tsx
+++ b/spacesim/src/components/testView.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'preact';
+import TestView from './TestView';
+
+describe('TestView', () => {
+  it('loads layout from storage', () => {
+    localStorage.setItem('test-layout', JSON.stringify({ a:{x:50,y:60}, b:{x:0,y:0}, c:{x:0,y:0} }));
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<TestView />, container);
+    const a = container.querySelector('[data-id="a"]') as HTMLElement;
+    expect(a.style.left).toBe('50px');
+    expect(a.style.top).toBe('60px');
+    localStorage.removeItem('test-layout');
+  });
+
+  it('toggles lock state', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<TestView />, container);
+    const btn = container.querySelector('.lock-toggle') as HTMLButtonElement;
+    expect(btn.dataset.locked).toBe('true');
+    btn.click();
+    await Promise.resolve();
+    expect(btn.dataset.locked).toBe('false');
+  });
+});

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -330,3 +330,7 @@ canvas {
 }
 
 .burn-controls { position:absolute; bottom:0; left:0; right:0; padding:0.25rem; }
+
+.draggable {
+  position: absolute;
+}


### PR DESCRIPTION
## Summary
- let UI pieces float around with new TestView and Draggable component
- mount TestView from the menu
- document the feature

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm --silent test` *(fails: apt packages required by Playwright can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881cb6b51e88320867ac37f173f7bdd