### PR TITLE
Fix default layout lock state

### DIFF
--- a/spacesim/src/components/TestView.tsx
+++ b/spacesim/src/components/TestView.tsx
@@ -15,7 +15,7 @@ export default function TestView() {
     const stored = localStorage.getItem(STORAGE_KEY);
     return stored ? JSON.parse(stored) : defaultLayout;
   });
-  const [locked, setLocked] = useState(true);
+  const [locked, setLocked] = useState(false);
 
   const move = (id: string, x: number, y: number) => {
     setLayout(l => ({ ...l, [id]: { x, y } }));

--- a/spacesim/src/components/shipView.test.tsx
+++ b/spacesim/src/components/shipView.test.tsx
@@ -27,6 +27,7 @@ describe('ShipView', () => {
     document.body.appendChild(container);
     render(<ShipView />, container);
     await Promise.resolve();
+    await Promise.resolve();
     const rootEl = container.querySelector('.shipview') as HTMLElement;
     rootEl.dispatchEvent(new MouseEvent('mousemove', { clientX: window.innerWidth - 1, bubbles: true }));
     await new Promise(r => setTimeout(r, 0));
@@ -60,6 +61,7 @@ describe('ShipView', () => {
     vi.advanceTimersByTime(20);
     window.dispatchEvent(new window.KeyboardEvent('keyup', { key: 'd', bubbles: true }));
     vi.advanceTimersByTime(40);
+    await Promise.resolve();
     expect(img.style.transform).not.toBe(initial);
     vi.useRealTimers();
   });

--- a/spacesim/src/components/testView.test.tsx
+++ b/spacesim/src/components/testView.test.tsx
@@ -19,9 +19,9 @@ describe('TestView', () => {
     document.body.appendChild(container);
     render(<TestView />, container);
     const btn = container.querySelector('.lock-toggle') as HTMLButtonElement;
-    expect(btn.dataset.locked).toBe('true');
+    expect(btn.dataset.locked).toBe('false');
     btn.click();
     await Promise.resolve();
-    expect(btn.dataset.locked).toBe('false');
+    expect(btn.dataset.locked).toBe('true');
   });
 });


### PR DESCRIPTION
## Summary
- unlock TestView by default so draggable items can be moved immediately
- update tests for new initial state
- stabilize ShipView keyboard test timing

## Testing
- `npm test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6881cf68b9f88320bf649b5c8e7e131a