### PR TITLE
Fix star window rendering

### DIFF
--- a/spacesim/src/components/WindowView.tsx
+++ b/spacesim/src/components/WindowView.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function WindowView({ yaw, pitch }: Props) {
   const imgRef = useRef<HTMLDivElement>(null);
-  const base = import.meta.env.BASE_URL;
+  const starsUrl = new URL('../../images/hdr_stars.jpeg', import.meta.url).href;
 
   useEffect(() => {
     if (!imgRef.current) return;
@@ -22,7 +22,7 @@ export default function WindowView({ yaw, pitch }: Props) {
       <div
         ref={imgRef}
         className="window-image"
-        style={{ backgroundImage: `url(${base}images/hdr_stars.jpeg)` }}
+        style={{ backgroundImage: `url(${starsUrl})` }}
       />
     </div>
   );

--- a/spacesim/src/components/windowView.test.tsx
+++ b/spacesim/src/components/windowView.test.tsx
@@ -10,6 +10,7 @@ describe('WindowView', () => {
     await new Promise(r => setTimeout(r, 50));
     const img = container.querySelector('.window-image') as HTMLElement;
     expect(img.style.transform.length).toBeGreaterThan(0);
+    expect(img.style.backgroundImage).toContain('hdr_stars');
     render(<WindowView yaw={-10} pitch={0} />, container);
     await new Promise(r => setTimeout(r, 50));
     expect(img.style.transform).not.toBe('');


### PR DESCRIPTION
## Summary
- ensure `WindowView` loads the star background using a URL relative to the module
- validate that the background image is set in tests

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm --prefix spacesim test -- -t WindowView` *(fails: Coverage for lines (20.96%) does not meet global threshold (60%))*

------
https://chatgpt.com/codex/tasks/task_e_6881cff6545c8320bc701defee981f90