### PR TITLE
Fix cockpit layout and controls

### DIFF
--- a/spacesim/src/components/NavigationView.tsx
+++ b/spacesim/src/components/NavigationView.tsx
@@ -27,17 +27,11 @@ export default function NavigationView({ sim: ext }: Props) {
   return (
     <div style={{ position:'relative', width:'100%', height:'100%' }}>
       <CanvasView sim={sim} onMouseDown={down} onMouseMove={move} onMouseUp={up} />
-      <div className="panel" style={{ position:'absolute', top:'10px', right:'10px', display:'flex', flexDirection:'column', gap:'0.25rem' }}>
-        <div style={{ display:'flex', justifyContent:'center' }}>
-          <button onClick={() => pan(0, -20)}>↑</button>
-        </div>
-        <div style={{ display:'flex', gap:'0.25rem', justifyContent:'center' }}>
-          <button onClick={() => pan(-20, 0)}>←</button>
-          <button onClick={() => pan(20, 0)}>→</button>
-        </div>
-        <div style={{ display:'flex', justifyContent:'center' }}>
-          <button onClick={() => pan(0, 20)}>↓</button>
-        </div>
+      <div className="edge-buttons">
+        <button className="btn-up" onClick={() => pan(0, -20)}>↑</button>
+        <button className="btn-left" onClick={() => pan(-20, 0)}>←</button>
+        <button className="btn-right" onClick={() => pan(20, 0)}>→</button>
+        <button className="btn-down" onClick={() => pan(0, 20)}>↓</button>
       </div>
     </div>
   );

--- a/spacesim/src/components/WindowView.tsx
+++ b/spacesim/src/components/WindowView.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 export default function WindowView({ yaw, pitch }: Props) {
   const imgRef = useRef<HTMLDivElement>(null);
-  const starsUrl = new URL('../../images/hdr_stars.jpeg', import.meta.url).href;
+  const starsUrl = `${import.meta.env.BASE_URL}images/hdr_stars.jpeg`;
 
   useEffect(() => {
     if (!imgRef.current) return;

--- a/spacesim/src/components/navigationView.test.tsx
+++ b/spacesim/src/components/navigationView.test.tsx
@@ -10,8 +10,9 @@ describe('NavigationView', () => {
     document.body.appendChild(container);
     render(<NavigationView sim={sim} />, container);
     expect(container.querySelector('canvas')).not.toBeNull();
-    const btn = container.querySelector('button') as HTMLButtonElement;
-    btn.click();
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(4);
+    (buttons[0] as HTMLButtonElement).click();
     expect(sim.pan).toHaveBeenCalled();
   });
 });

--- a/spacesim/style.css
+++ b/spacesim/style.css
@@ -207,8 +207,9 @@ canvas {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #222;
+  background: linear-gradient(#222, #111);
   border: 1px solid #0ff;
+  box-shadow: inset 0 0 10px #000;
   box-sizing: border-box;
 }
 
@@ -241,12 +242,14 @@ canvas {
 }
 
 .ship-left {
-  transform: rotateY(15deg) skewY(-2deg);
+  transform: rotateY(18deg) skewY(-2deg);
+  border-right-color: #066;
 }
 
 .ship-right {
   position: relative;
-  transform: rotateY(-15deg) skewY(2deg);
+  transform: rotateY(-18deg) skewY(2deg);
+  border-left-color: #066;
 }
 
 .ship-console {
@@ -271,14 +274,15 @@ canvas {
 .console-screen {
   left: 0;
   bottom: 60px;
-  height: 40%;
+  width: 30%;
+  height: 35%;
 }
 
 .nav-screen {
   right: 0;
   top: 0;
-  width: 60%;
-  height: 60%;
+  width: 70%;
+  height: 80%;
 }
 
 .nav-static {
@@ -296,6 +300,30 @@ canvas {
 }
 
 .burn-controls { position:absolute; bottom:0; left:0; right:0; padding:0.25rem; }
+
+.edge-buttons button {
+  position: absolute;
+}
+.edge-buttons .btn-up {
+  top: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.edge-buttons .btn-down {
+  bottom: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.edge-buttons .btn-left {
+  left: 5px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.edge-buttons .btn-right {
+  right: 5px;
+  top: 50%;
+  transform: translateY(-50%);
+}
 
 .hud-menu {
   position: absolute;


### PR DESCRIPTION
## Summary
- refine ship cockpit styling for better 3D look
- enlarge nav screen and tweak console screen
- reposition nav view buttons around screen edges
- load star background using BASE_URL
- update navigation view tests for new buttons

## Testing
- `npm install`
- `npm --prefix spacesim install`
- `npm test` *(fails: `vitest` OOM)*

------
https://chatgpt.com/codex/tasks/task_e_68820a15bf84832090332b8f2a481c00