### PR TITLE
fix: reset spawn defaults on reset

### DIFF
--- a/bugfix/reset-spawn-default/README.md
+++ b/bugfix/reset-spawn-default/README.md
@@ -1,0 +1,14 @@
+# Reset spawn default
+
+## Issue
+Pressing the Reset button cleared the simulation but left the spawner set to the last planet preset. Subsequent bodies spawned as planets instead of starting again from the Sun preset.
+
+## Root cause
+`Simulation` reset handled world state only. `SimulationComponent` kept its `spawnParams` state unchanged, so the UI continued using the previous planet parameters.
+
+## Fix
+The reset handler now also restores the initial Sun spawn parameters. A unit test reproduces the bug and verifies the fix.
+
+## References
+- Implementation commit
+- [practices/BUGFIX.md](../../practices/BUGFIX.md)

--- a/spacesim/README.md
+++ b/spacesim/README.md
@@ -4,7 +4,7 @@ A simple 3D physics sandbox illustrating basic orbital mechanics. The project us
 
 Bodies are spawned by dragging on the canvas while the spawner panel is visible. The drag length defines the initial velocity and short drags create a body with near-zero velocity. A green line shows the drag vector as you hold the mouse. When released a body is created with a unique label from the spawner panel. The first spawn defaults to a **Sun** with mass 100, radius 50 and yellow color. After that the spawner switches to a **planet** preset with random color for each new body. Mass now uses a slider scaled from a small moon to the Sun and all distances are shown in metric units.
 
-Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded using the **Scenario** button within the sandbox; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
+Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded using the **Scenario** button within the sandbox; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation. Reset also restores the Sun preset for the next spawned body.
 
 A new **Shipview** tab displays a basic cockpit layout. Three angled panels and
 a bottom console create a simple 3D illusion. The centre "window" hosts the

--- a/spacesim/docs/1/spacesim/README.md
+++ b/spacesim/docs/1/spacesim/README.md
@@ -4,7 +4,7 @@ A simple 2D physics sandbox illustrating basic orbital mechanics. The project us
 
 Bodies are spawned by dragging on the canvas while the spawner panel is visible. The drag length defines the initial velocity and short drags create a body with near-zero velocity. A green line shows the drag vector as you hold the mouse. When released a body is created with a unique label from the spawner panel. The first spawn defaults to a **Sun** with mass 100, radius 50 and yellow color. After that the spawner switches to a **planet** preset with random color for each new body.
 
-Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation.
+Clicking an existing body opens an editor panel. The editor now shows live position and velocity values which can be edited alongside mass, radius and color. Scenarios (predefined sequences of events) can be loaded from the Scenario tab; a simple Solar System example is included. The top-right of the screen contains **Pause** and **Reset** buttons to control the simulation. Reset also restores the Sun preset for the next spawned body.
 
 The simulation is built from small modules connected through a simple event bus powered by **mitt**. `GameLoop` ticks once per animation frame using RxJS and passes the elapsed time to the simulation. `PhysicsEngine` handles Planck.js dynamics. A single `ThreeRenderer` listens for render events and draws bodies, orbit trails and the drag line using Three.js.
 

--- a/spacesim/src/components/Simulation.tsx
+++ b/spacesim/src/components/Simulation.tsx
@@ -9,6 +9,8 @@ import ScenarioChooser from './ScenarioChooser';
 import { Vec3 } from '../vector';
 import { uniqueName, throwVelocity, nextSpawnParams } from '../utils';
 
+const defaultSpawn = { mass: 100, radius: 50, color: '#ffff00', label: 'Sun' };
+
 interface Props {
   scenario?: ScenarioEvent[];
   sim?: Simulation; // for tests
@@ -25,7 +27,7 @@ export default function SimulationComponent({ scenario, sim: ext, showSpawner = 
   }, [sim]);
   const [running, setRunning] = useState(true);
   const [selected, setSelected] = useState<ReturnType<Simulation['addBody']> | null>(null);
-  const [spawnParams, setSpawnParams] = useState({ mass:100, radius:50, color:'#ffff00', label:'Sun' });
+  const [spawnParams, setSpawnParams] = useState({ ...defaultSpawn });
   const [dragStart, setDragStart] = useState<Vec3 | null>(null);
   const [frame, setFrame] = useState(0);
   const [speed, setSpeed] = useState(sim.speed);
@@ -76,7 +78,13 @@ export default function SimulationComponent({ scenario, sim: ext, showSpawner = 
   };
 
   const toggleRun = () => setRunning(r=>!r);
-  const reset = () => { sim.reset(); setSelected(null); setDragStart(null); sim.resetView(); };
+  const reset = () => {
+    sim.reset();
+    setSelected(null);
+    setDragStart(null);
+    sim.resetView();
+    setSpawnParams({ ...defaultSpawn });
+  };
   const zoomIn = () => { sim.zoom(1.2); };
   const zoomOut = () => { sim.zoom(1/1.2); };
   const pan = (dx:number, dy:number) => { sim.pan(dx / sim.view.zoom, dy / sim.view.zoom); };

--- a/spacesim/src/components/simulationComponent.test.tsx
+++ b/spacesim/src/components/simulationComponent.test.tsx
@@ -61,4 +61,27 @@ describe('SimulationComponent', () => {
     render(<SimulationComponent sim={sim} showSpawner={false} />, container)
     expect(container.textContent).not.toContain('Click canvas to spawn')
   })
+
+  it('resets spawn defaults when clicking Reset', async () => {
+    const testSim = {
+      ...sim,
+      screenToWorld: (v: any) => v,
+    } as any
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    render(<SimulationComponent sim={testSim} />, container)
+    await new Promise(r => setTimeout(r, 20))
+    const canvas = container.querySelector('canvas') as HTMLCanvasElement
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 100, height: 100 } as any)
+    canvas.dispatchEvent(new MouseEvent('mousedown', { clientX: 0, clientY: 0, bubbles: true }))
+    canvas.dispatchEvent(new MouseEvent('mouseup', { clientX: 10, clientY: 0, bubbles: true }))
+    await new Promise(r => setTimeout(r))
+    const nameInput = container.querySelector('input') as HTMLInputElement
+    expect(nameInput.value).toBe('planet')
+    const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Reset') as HTMLButtonElement
+    btn.click()
+    await new Promise(r => setTimeout(r))
+    const resetInput = container.querySelector('input') as HTMLInputElement
+    expect(resetInput.value).toBe('Sun')
+  })
 })


### PR DESCRIPTION
## Summary
- reset spawn params to the Sun preset when clicking **Reset**
- test the behaviour in SimulationComponent
- document the bugfix and mention the new behaviour in docs

## Testing
- `npm test` *(fails: vitest OOM)*

------
https://chatgpt.com/codex/tasks/task_e_6882a4d1b0308320acfbf8ebc26c51ae