### PR TITLE
Streamline AGENTS files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Welcome, coding agent! Follow these instructions whenever you work in this repos
    - Format commit messages according to [`docs/practices/COMMIT_MESSAGE.md`](docs/practices/COMMIT_MESSAGE.md).
    - Write tests before implementing any change and ensure they all pass.
 3. **Maintain Local Instructions**
-   - Some subfolders include their own `AGENTS.md` with additional guidance. If present, read it before editing files in that folder.
+   - Some folders include their own `AGENTS.md` with notes specific to that location. Keep these files short and link back here rather than repeating the entire workflow. If present, read them before editing files in that folder.
 
 These practices must not be altered without explicit approval. Raise concerns rather than modifying them silently.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Welcome to Codex2! This repository is scaffolded using **documentation-driven development**. Create a `README.md` and an `AGENTS.md` in a folder only when it adds context or rules that aren't already covered by its parent directories. These documents help both human developers and AI coding agents understand the structure, intent, and rules of the codebase.
 
 - `README.md` explains the purpose of the code within its folder and links to any additional documentation. Add one only when the folder introduces concepts not documented elsewhere.
-- `AGENTS.md` provides AI-specific guidance for contributing safely and consistently. Include it when specialised instructions are needed for that folder.
+- `AGENTS.md` provides AI-specific guidance for contributing safely and consistently. Include it only when a folder needs extra notes and always link back to `/AGENTS.md` for the full workflow.
 - For any UI work consult [`practices/UI.md`](practices/UI.md) for design guidelines.
 
 A detailed workflow for all contributors is defined in [`practices/CODING_RULES.md`](practices/CODING_RULES.md). Core practices such as testing, feature work, bug fixing and refactoring are documented in the [`practices/`](practices/) folder. You should read those guidelines, including the commit message rules in [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md), before proposing any changes. Further design or architecture notes may appear in other Markdown files, and they will be referenced from the local `README.md` and `AGENTS.md`.

--- a/spacesim/AGENTS.md
+++ b/spacesim/AGENTS.md
@@ -1,8 +1,8 @@
-# Instructions for AI Coding Agents
+# Spacesim Folder Instructions
 
-- Start by reviewing the repository-level [AGENTS.md](../AGENTS.md).
+See [../AGENTS.md](../AGENTS.md) for the full workflow.
+
+Additional notes:
 - Keep the simulation minimal and well-documented.
 - Use Three.js vectors for physics calculations in 3D.
-- Provide unit tests for any logic in `src/`.
-- Run `npm install` before testing or building.
-- When adjusting the UI, follow [../practices/UI.md](../practices/UI.md).
+- Provide unit tests for logic in `src/`.

--- a/spacesim/docs/1/AGENTS.md
+++ b/spacesim/docs/1/AGENTS.md
@@ -1,19 +1,3 @@
-# Guidance for AI Coding Agents
+# Documentation Snapshot
 
-Welcome, coding agent! Follow these instructions whenever you work in this repository:
-
-1. **Read Documentation First**
-   - Review the current folder's `README.md` and `AGENTS.md` along with those of its parents.
-   - Consult the documents in [`practices/`](practices/) for testing, feature, bug fix and refactoring procedures.
-   - When working on user interfaces, also read [`practices/UI.md`](practices/UI.md).
-2. **Comply with the Workflow**
-   - Follow the standards defined in [`practices/CODING_RULES.md`](practices/CODING_RULES.md).
-   - Format commit messages according to [`practices/COMMIT_MESSAGE.md`](practices/COMMIT_MESSAGE.md).
-   - Write tests before implementing any change and ensure they all pass.
-3. **Maintain Local Instructions**
-   - Some subfolders include their own `AGENTS.md` with additional guidance. If present, read it before editing files in that folder.
-
-These practices must not be altered without explicit approval. Raise concerns rather than modifying them silently.
-
-## Environment Note
-If `npm test` prints `npm warn Unknown env config "http-proxy"`, the environment has `npm_config_http_proxy` or `npm_config_https_proxy` set. Unset these variables (or use the newer `npm_config_proxy` names) to silence the warning.
+See [../../AGENTS.md](../../AGENTS.md) for the repository workflow. This folder archives earlier docs and has no additional rules.

--- a/spacesim/docs/1/spacesim/AGENTS.md
+++ b/spacesim/docs/1/spacesim/AGENTS.md
@@ -1,8 +1,3 @@
-# Instructions for AI Coding Agents
+# Spacesim v1 Instructions
 
-- Start by reviewing the repository-level [AGENTS.md](../AGENTS.md).
-- Keep the simulation minimal and well-documented.
-- Use Planck.js for physics calculations.
-- Provide unit tests for any logic in `src/`.
-- Run `npm install` before testing or building.
-- When adjusting the UI, follow [../practices/UI.md](../practices/UI.md).
+Refer to [../../AGENTS.md](../../AGENTS.md) for the workflow. This archived version uses Planck.js for 2D physics.


### PR DESCRIPTION
## Summary
- clarify that subfolder AGENTS should link back to the repo root
- tweak root README to emphasize linking to `/AGENTS.md`
- trim AGENTS files under `spacesim` and docs to only local notes

## Testing
- `npm install`
- `npm --prefix spacesim install`
- `npm test` *(fails: Channel closed / heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6882a61a32908320956f6db9fc4bdb40