### PR TITLE
Fix spawn reset test and increase memory limit

### DIFF
--- a/spacesim/package.json
+++ b/spacesim/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "npm test && vite build",
     "preview": "vite preview",
-    "test": "vitest run --coverage",
+    "test": "NODE_OPTIONS=--max_old_space_size=4096 vitest run --coverage",
     "pretest:e2e": "playwright install --with-deps",
     "test:e2e": "playwright test",
     "test:perf": "vitest bench --run --config vitest.performance.config.ts --outputJson performance/latest.json && node performance/compare.js"

--- a/spacesim/src/components/simulationComponent.test.tsx
+++ b/spacesim/src/components/simulationComponent.test.tsx
@@ -74,6 +74,7 @@ describe('SimulationComponent', () => {
     const canvas = container.querySelector('canvas') as HTMLCanvasElement
     canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 100, height: 100 } as any)
     canvas.dispatchEvent(new MouseEvent('mousedown', { clientX: 0, clientY: 0, bubbles: true }))
+    await new Promise(r => setTimeout(r))
     canvas.dispatchEvent(new MouseEvent('mouseup', { clientX: 10, clientY: 0, bubbles: true }))
     await new Promise(r => setTimeout(r))
     const nameInput = container.querySelector('input') as HTMLInputElement


### PR DESCRIPTION
## Summary
- stabilize `SimulationComponent` tests by waiting for state updates
- bump memory for `vitest` runs

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npx vitest run src/components/simulationComponent.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6882aa90e4f08320be048d262b3e6440