### PR TITLE
Add mouse event callbacks to CanvasView

### DIFF
--- a/spacesim/src/components/CanvasView.tsx
+++ b/spacesim/src/components/CanvasView.tsx
@@ -5,6 +5,9 @@ import { Vec3 } from '../vector';
 interface Props {
   sim: Simulation;
   onClick?: (pos: Vec3) => void;
+  onMouseDown?: (pos: Vec3) => void;
+  onMouseMove?: (pos: Vec3) => void;
+  onMouseUp?: (pos: Vec3) => void;
 }
 
 export default function CanvasView({ sim, onClick, onMouseDown, onMouseMove, onMouseUp }: Props) {


### PR DESCRIPTION
## Summary
- expose onMouseDown, onMouseMove and onMouseUp props

## Testing
- `npx tsc src/components/CanvasView.tsx --jsx react-jsx --jsxImportSource preact --moduleResolution bundler --target es2022 --module esnext --noEmit` *(fails: Could not find module three)*
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6882af395594832092832588386eeec1