### PR TITLE
Fix windowView test to respect base URL

### DIFF
--- a/spacesim/src/components/windowView.test.tsx
+++ b/spacesim/src/components/windowView.test.tsx
@@ -9,7 +9,9 @@ describe('WindowView', () => {
     render(<WindowView yaw={10} pitch={0} />, container);
     await new Promise(r => setTimeout(r, 50));
     const img = container.querySelector('.window-image') as HTMLElement;
+    const base = import.meta.env.BASE_URL;
     expect(img.style.transform.length).toBeGreaterThan(0);
+    expect(img.style.backgroundImage.startsWith(`url("${base}`)).toBe(true);
     expect(img.style.backgroundImage).toContain('hdr_stars');
     render(<WindowView yaw={-10} pitch={0} />, container);
     await new Promise(r => setTimeout(r, 50));


### PR DESCRIPTION
## Summary
- check base path when verifying window background

## Testing
- `npm --prefix spacesim test`


------
https://chatgpt.com/codex/tasks/task_e_6882af752c488320ae38d6c2e4b713b5